### PR TITLE
Suppor ordered list

### DIFF
--- a/src/html.rs
+++ b/src/html.rs
@@ -1,7 +1,6 @@
 use parser::Block;
-use parser::ListItem;
-use parser::Block::{Header, Paragraph, Blockquote, Hr, CodeBlock, UnorderedList, Raw};
-use parser::Span;
+use parser::Block::{Header, Paragraph, Blockquote, Hr, CodeBlock, UnorderedList, OrderedList, Raw};
+use parser::{Span, ListItem, OrderedListType};
 use parser::Span::{Break, Text, Emphasis, Strong, Code, Link, Image};
 
 // takes a number of elements and returns their collective text as a slug
@@ -35,6 +34,7 @@ pub fn to_html(blocks: &[Block]) -> String {
             Blockquote(ref elements) => format_blockquote(elements),
             CodeBlock(ref elements) => format_codeblock(elements),
             UnorderedList(ref elements) => format_unordered_list(elements),
+            OrderedList(ref elements, ref num_type) => format_ordered_list(elements,num_type),
             Raw(ref elements) => elements.to_owned(),
             Hr => format!("<hr>"),
         };
@@ -81,7 +81,7 @@ fn escape(text: &str) -> String {
         .replace(">", "&gt;")
 }
 
-fn format_unordered_list(elements: &[ListItem]) -> String {
+fn format_list(elements: &[ListItem], start_tag: &str, end_tag: &str) -> String {
     let mut ret = String::new();
     for list_item in elements {
         let mut content = String::new();
@@ -96,7 +96,15 @@ fn format_unordered_list(elements: &[ListItem]) -> String {
 
         ret.push_str(&format!("\n<li>{}</li>\n", content))
     }
-    format!("<ul>{}</ul>\n\n", ret)
+    format!("<{}>{}</{}>\n\n", start_tag, ret, end_tag)
+}
+
+fn format_unordered_list(elements: &[ListItem]) -> String {
+    format_list(elements, "ul", "ul")
+}
+
+fn format_ordered_list(elements: &[ListItem], num_type: &OrderedListType) -> String {
+    format_list(elements, &format!("ol type=\"{}\"", num_type.0), "ol")
 }
 
 fn format_codeblock(elements: &str) -> String {

--- a/src/markdown_generator/mod.rs
+++ b/src/markdown_generator/mod.rs
@@ -20,7 +20,8 @@ fn gen_block(b : Block) -> String {
         Paragraph(s) => generate_from_spans(s),
         Blockquote(bb) => generate(bb).lines().map(|x|format!("> {}", x)).j("\n"),
         CodeBlock(x) => x.lines().map(|x|format!("    {}",x)).j("\n"),
-        //OrderedList(Vec<ListItem>),
+        // [TODO]: Ordered list generation - 2017-12-10 10:12pm
+        OrderedList(_x,_num_type) => unimplemented!("Generate ordered list"),
         UnorderedList(x) => generate_from_li(x),
         Raw(x) => x,
         Hr => "\n\n".to_string(),
@@ -37,7 +38,6 @@ fn gen_span(s : Span) -> String {
         Link(a, b, Some(c))  => format!("[{}]({} \"{}\")", a, b, c),
         Image(a, b, None)    => format!("![{}]({})", a, b),
         Image(a, b, Some(c)) => format!("![{}]({} \"{}\")", a, b, c),
-    
         Emphasis(x) => format!("*{}*",   generate_from_spans(x)),
         Strong(x)   => format!("**{}**", generate_from_spans(x)),
     }
@@ -49,7 +49,7 @@ fn generate_from_li(data: Vec<ListItem>) -> String {
 
     data.into_iter().map(|x|format!("* {}", match x {
         Simple(x) => generate_from_spans(x),
-        Paragraph(x) => format!("{}\n", 
+        Paragraph(x) => format!("{}\n",
                             generate(x)
                             .lines()
                             .enumerate()

--- a/src/parser/block/mod.rs
+++ b/src/parser/block/mod.rs
@@ -9,12 +9,14 @@ mod hr;
 mod code_block;
 mod blockquote;
 mod unordered_list;
+mod ordered_list;
 use self::atx_header::parse_atx_header;
 use self::setext_header::parse_setext_header;
 use self::hr::parse_hr;
 use self::code_block::parse_code_block;
 use self::blockquote::parse_blockquote;
 use self::unordered_list::parse_unordered_list;
+use self::ordered_list::parse_ordered_list;
 
 pub fn parse_blocks (md : &str) -> Vec<Block> {
     let mut blocks = vec![];
@@ -74,6 +76,7 @@ fn parse_block (lines: &[&str]) -> Option<(Block, usize)>{
         => parse_code_block
         => parse_blockquote
         => parse_unordered_list
+        => parse_ordered_list
         )
 }
 

--- a/src/parser/block/ordered_list.rs
+++ b/src/parser/block/ordered_list.rs
@@ -149,7 +149,7 @@ mod test {
             Some( (OrderedList(ref items, ref lt), 3) ) if lt == &n_type() =>
                 match &items[0] {
                     &Paragraph(ref items) => match &items[1] {
-                        &OrderedList(_, ref lt1) if lt == &n_type() => (),
+                        &OrderedList(_, ref lt1) if lt1 == &n_type() => (),
                         x => panic!("Found {:?}", x),
                     }
                     x => panic!("Found {:?}", x),

--- a/src/parser/block/ordered_list.rs
+++ b/src/parser/block/ordered_list.rs
@@ -1,0 +1,168 @@
+use parser::Block;
+use parser::block::parse_blocks;
+use parser::Block::{OrderedList, Paragraph};
+use parser::{ ListItem, OrderedListType };
+use regex::Regex;
+
+pub fn parse_ordered_list(lines:  &[&str]) -> Option<(Block, usize)> {
+    lazy_static! {
+        static ref LIST_BEGIN :Regex = Regex::new(r"^(?P<indent> *)(?P<numbering>[0-9.]+|[aAiI]+\.) (?P<content>.*)").unwrap();
+        static ref NEW_PARAGRAPH :Regex = Regex::new(r"^ +").unwrap();
+        static ref INDENTED :Regex = Regex::new(r"^ {0,4}(?P<content>.*)").unwrap();
+    }
+
+    // if the beginning doesn't match a list don't even bother
+    if !LIST_BEGIN.is_match(lines[0]) {
+        return None;
+    }
+
+    // a vec holding the contents and indentation
+    // of each list item
+    let mut contents = vec![];
+    let mut prev_newline = false;
+    let mut is_paragraph = false;
+
+    // counts the number of parsed lines to return
+    let mut i = 0;
+
+    let mut line_iter = lines.iter();
+    let mut line = line_iter.next();
+    let mut list_num_opt = None;
+
+    // loop for list items
+    loop {
+        if line.is_none() || !LIST_BEGIN.is_match(line.unwrap()) {
+            break;
+        }
+        if prev_newline {
+            is_paragraph = true;
+            prev_newline = false;
+        }
+
+        let caps = LIST_BEGIN.captures(line.unwrap()).unwrap();
+
+        let mut content = caps.name("content").unwrap().as_str().to_owned();
+        let last_indent = caps.name("indent").unwrap().as_str().len();
+        //We use the first list type found
+        let list_num = caps.name("numbering").unwrap().as_str()[0..1].to_owned();
+        list_num_opt = list_num_opt.or(Some(list_num));
+        i += 1;
+
+        // parse additional lines of the listitem
+        loop {
+            line = line_iter.next();
+
+            if line.is_none() || (prev_newline && !NEW_PARAGRAPH.is_match(line.unwrap())) {
+                break;
+            }
+
+            if LIST_BEGIN.is_match(line.unwrap()) {
+                let caps = LIST_BEGIN.captures(line.unwrap()).unwrap();
+                let indent = caps.name("indent").unwrap().as_str().len();
+                if indent < 2 || indent <= last_indent {
+                    break;
+                }
+            }
+
+            // newline means we start a new paragraph
+            if line.unwrap().is_empty() {
+                prev_newline = true;
+            } else {
+                prev_newline = false;
+            }
+
+            content.push('\n');
+            let caps = INDENTED.captures(line.unwrap()).unwrap();
+            content.push_str(&caps.name("content").unwrap().as_str());
+
+            i += 1;
+        }
+        contents.push(parse_blocks(&content));
+    }
+
+    let mut list_contents = vec![];
+
+    for c in contents {
+        if is_paragraph || c.len() > 1 {
+            list_contents.push(ListItem::Paragraph(c));
+        } else if let Paragraph(content) = c[0].clone() {
+            list_contents.push(ListItem::Simple(content));
+        }
+    }
+
+    if i > 0 {
+        let list_num = list_num_opt.unwrap_or("1".to_string());
+        return Some((OrderedList(list_contents,
+                                 OrderedListType( list_num)), i));
+    }
+
+    None
+}
+
+#[allow(non_snake_case)]
+#[cfg(test)]
+mod test {
+    use super::parse_ordered_list;
+    use parser::Block::OrderedList;
+    use parser::OrderedListType;
+    fn a_type() -> OrderedListType  { OrderedListType("a".to_string()) }
+    fn A_type() -> OrderedListType  { OrderedListType("A".to_string()) }
+    fn i_type() -> OrderedListType  { OrderedListType("i".to_string()) }
+    fn I_type() -> OrderedListType  { OrderedListType("I".to_string()) }
+    fn n_type() -> OrderedListType  { OrderedListType("1".to_string()) }
+
+    #[test]
+    fn finds_list() {
+        match parse_ordered_list(&vec!["1. A list", "2. is good"]) {
+            Some( (OrderedList(_, ref lt ), 2) ) if lt == &n_type() => (),
+            x => panic!("Found {:?}", x),
+        }
+
+        match parse_ordered_list(&vec!["a. A list", "b. is good", "laksjdnflakdsjnf"]) {
+            Some( (OrderedList(_, ref lt ), 3) ) if lt == &a_type() => (),
+            x => panic!("Found {:?}", x),
+        }
+
+        match parse_ordered_list(&vec!["A. A list", "B. is good", "laksjdnflakdsjnf"]) {
+            Some( (OrderedList(_, ref lt ), 3) ) if lt == &A_type() => (),
+            x => panic!("Found {:?}", x),
+        }
+    }
+
+    #[test]
+    fn knows_when_to_stop() {
+        match parse_ordered_list(&vec!["i. A list", "ii. is good", "", "laksjdnflakdsjnf"]) {
+            Some( (OrderedList(_, ref lt ), 3) ) if lt == &i_type() => (),
+            x => panic!("Found {:?}", x),
+        }
+
+        match parse_ordered_list(&vec!["I. A list", "", "laksjdnflakdsjnf"]) {
+            Some( (OrderedList(_, ref lt), 2) ) if lt == &I_type() => (),
+            x => panic!("Found {:?}", x),
+        }
+    }
+
+    #[test]
+    fn multi_level_list() {
+        match parse_ordered_list(&vec!["1. A list", "     1.1. One point one", "     1.2. One point two"]) {
+             // Some((OrderedList([Paragraph([Paragraph([Text("A list")]), OrderedList([Simple([Text("One point one")]), Simple([Text("One point two")])], OrderedListType("1"))])], OrderedListType("1")), 3)) => (),
+            Some( (OrderedList(ref items, ref lt), 3) ) if lt == &n_type() =>
+                match items[1] {
+                    OrderedList(_, ref lt1) if lt == &n_type() => (),
+                    x => panic!("Found {:?}", x),
+                },
+            x => panic!("Found {:?}", x),
+        }
+    }
+
+    #[test]
+    fn no_false_positives() {
+        assert_eq!(parse_ordered_list(&vec!["test 1. test"]), None);
+    }
+
+    #[test]
+    fn no_early_matching() {
+        assert_eq!(parse_ordered_list(&vec!["test", "1. not", "2. a list"]),
+                   None);
+    }
+}

--- a/src/parser/block/ordered_list.rs
+++ b/src/parser/block/ordered_list.rs
@@ -146,7 +146,6 @@ mod test {
     #[test]
     fn multi_level_list() {
         match parse_ordered_list(&vec!["1. A list", "     1.1. One point one", "     1.2. One point two"]) {
-             // Some((OrderedList([Paragraph([Paragraph([Text("A list")]), OrderedList([Simple([Text("One point one")]), Simple([Text("One point two")])], OrderedListType("1"))])], OrderedListType("1")), 3)) => (),
             Some( (OrderedList(ref items, ref lt), 3) ) if lt == &n_type() =>
                 match &items[0] {
                     &Paragraph(ref items) => match &items[1] {

--- a/src/parser/block/ordered_list.rs
+++ b/src/parser/block/ordered_list.rs
@@ -105,6 +105,7 @@ mod test {
     use super::parse_ordered_list;
     use parser::Block::OrderedList;
     use parser::OrderedListType;
+    use parser::ListItem::Paragraph;
     fn a_type() -> OrderedListType  { OrderedListType("a".to_string()) }
     fn A_type() -> OrderedListType  { OrderedListType("A".to_string()) }
     fn i_type() -> OrderedListType  { OrderedListType("i".to_string()) }
@@ -147,12 +148,16 @@ mod test {
         match parse_ordered_list(&vec!["1. A list", "     1.1. One point one", "     1.2. One point two"]) {
              // Some((OrderedList([Paragraph([Paragraph([Text("A list")]), OrderedList([Simple([Text("One point one")]), Simple([Text("One point two")])], OrderedListType("1"))])], OrderedListType("1")), 3)) => (),
             Some( (OrderedList(ref items, ref lt), 3) ) if lt == &n_type() =>
-                match items[1] {
-                    OrderedList(_, ref lt1) if lt == &n_type() => (),
+                match &items[0] {
+                    &Paragraph(ref items) => match &items[1] {
+                        &OrderedList(_, ref lt1) if lt == &n_type() => (),
+                        x => panic!("Found {:?}", x),
+                    }
                     x => panic!("Found {:?}", x),
                 },
             x => panic!("Found {:?}", x),
         }
+
     }
 
     #[test]

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -2,13 +2,18 @@ mod span;
 mod block;
 
 #[allow(missing_docs)]
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub struct OrderedListType(pub String);
+
+#[allow(missing_docs)]
 #[derive(Debug, PartialEq, Clone)]
 pub enum Block {
     Header(Vec<Span>, usize),
     Paragraph(Vec<Span>),
     Blockquote(Vec<Block>),
     CodeBlock(String),
-    //OrderedList(Vec<ListItem>),
+    //String is the type of list: A,a,i,I or 1
+    OrderedList(Vec<ListItem>,OrderedListType),
     UnorderedList(Vec<ListItem>),
     Raw(String),
     Hr


### PR DESCRIPTION
This PR supports ordered lists, it also works with multilevel numbers like 1.1. , 1.2. , 1.3. , 2.3. , etc. Tests are included.