### PR TITLE
Allow code blocks with three backticks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,9 @@
 [package]
-
-name = "markdown"
-version = "0.2.0"
-authors = ["Johann Hofmann <mail@johann-hofmann.com>"]
+name = "markly"
+version = "0.3.0"
+authors = ["Brad Alfirevic <brad@genbyte.dev>", "Johann Hofmann <mail@johann-hofmann.com>"]
 description = "Native Rust library for parsing Markdown and (outputting HTML)"
-repository = "https://github.com/johannhof/markdown.rs"
+repository = "https://github.com/genuinebyte/markly.rs"
 readme = "README.md"
 keywords = ["markdown", "md", "html", "parser"]
 license = "MIT OR Apache-2.0"
@@ -14,7 +13,7 @@ exclude = [
 ]
 
 [[bin]]
-name = "markdown"
+name = "markly"
 doc = false
 
 [features]

--- a/README.md
+++ b/README.md
@@ -33,7 +33,6 @@ TODO
 - [ ] Inline HTML
 - [ ] Backslash Escapes
 - [ ] Automatic Links
-- [ ] Reference-Style Links
 - [ ] List wrapping
 - [ ] HTML Entities
 - [ ] Obscure Emails

--- a/README.md
+++ b/README.md
@@ -1,28 +1,36 @@
-markdown.rs [![](https://travis-ci.org/johannhof/markdown.rs.svg?branch=master)](https://travis-ci.org/johannhof/markdown.rs) [![](https://img.shields.io/crates/v/markdown.svg)](https://crates.io/crates/markdown) [![](https://coveralls.io/repos/johannhof/markdown.rs/badge.svg?branch=master&service=github)](https://coveralls.io/github/johannhof/markdown.rs?branch=master)
+markly.rs [![Crate][crate_img]][crate]
 ===========
 
 A simple native Rust library for parsing Markdown and (outputting HTML).
 
+Forked from the [markdown crate][markdown_crate].
+
+[crate]: https://crates.io/crates/markly "Crate Page Link"
+[crate_img]: https://img.shields.io/crates/v/markly.svg?logo=rust "Crate Page Badge"
+[docs]: https://docs.rs/markly "Documentation Link"
+[docs_img]: https://docs.rs/markly/badge.svg "Documentation Badge"
+[markdown_crate]: https://crates.io/crates/markdown "Markdown Crate Page Link"
+
 Usage
 ----------
 
-To include markdown in your project add the following to your Cargo.toml:
+To include markly in your project add the following to your Cargo.toml:
 
 ```toml
 [dependencies]
-markdown = "0.2"
+markly = "0.3"
 
 ```
 
 Now you can use the crate in your code with
 ```rust
-extern crate markdown;
+use markly;
 ```
 
 There is no full documentation right now, the only function exported by the library is `to_html`, which takes a markdown `&str` and converts it to an owned `String` containing html.
 
 ```rust
-let html : String = markdown::to_html("__I am markdown__");
+let html : String = markly::to_html("__I am markdown__");
 
 assert_eq!(&html, "<strong>I am markdown</strong>")
 ```

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ assert_eq!(&html, "<strong>I am markdown</strong>")
 TODO
 ----------
 
+- [ ] Reference Style Images
 - [ ] Inline HTML
 - [ ] Backslash Escapes
 - [ ] Automatic Links

--- a/src/html.rs
+++ b/src/html.rs
@@ -99,11 +99,11 @@ fn format_unordered_list(elements: &[ListItem]) -> String {
     format!("<ul>{}</ul>\n\n", ret)
 }
 
-fn format_codeblock(language: &Option<String>,elements: &str) -> String {
-    if language.is_none() {
+fn format_codeblock(lang: &Option<String>,elements: &str) -> String {
+    if lang.is_none() || (lang.is_some() && lang.as_ref().unwrap().is_empty()) {
         format!("<pre><code>{}</code></pre>\n\n", &escape(elements))
     } else {
-        format!("<pre><code class=\"language-{}\">{}</code></pre>\n\n", &escape(language.as_ref().unwrap()), &escape(elements))
+        format!("<pre><code class=\"language-{}\">{}</code></pre>\n\n", &escape(lang.as_ref().unwrap()), &escape(elements))
     }
 }
 

--- a/src/html.rs
+++ b/src/html.rs
@@ -33,7 +33,7 @@ pub fn to_html(blocks: &[Block]) -> String {
             Header(ref elements, level) => format_header(elements, level),
             Paragraph(ref elements) => format_paragraph(elements),
             Blockquote(ref elements) => format_blockquote(elements),
-            CodeBlock(ref elements) => format_codeblock(elements),
+            CodeBlock(ref lang, ref elements) => format_codeblock(lang, elements),
             UnorderedList(ref elements) => format_unordered_list(elements),
             Raw(ref elements) => elements.to_owned(),
             Hr => format!("<hr>"),
@@ -99,8 +99,12 @@ fn format_unordered_list(elements: &[ListItem]) -> String {
     format!("<ul>{}</ul>\n\n", ret)
 }
 
-fn format_codeblock(elements: &str) -> String {
-    format!("<pre><code>{}</code></pre>\n\n", &escape(elements))
+fn format_codeblock(language: &Option<String>,elements: &str) -> String {
+    if language.is_none() {
+        format!("<pre><code>{}</code></pre>\n\n", &escape(elements))
+    } else {
+        format!("<pre><code class=\"language-{}\">{}</code></pre>\n\n", &escape(language.as_ref().unwrap()), &escape(elements))
+    }
 }
 
 fn format_blockquote(elements: &[Block]) -> String {

--- a/src/html.rs
+++ b/src/html.rs
@@ -1,6 +1,6 @@
 use parser::Block;
 use parser::Block::{
-    Blockquote, CodeBlock, Header, Hr, OrderedList, Paragraph, Raw, UnorderedList, LinkReference
+    Blockquote, CodeBlock, Header, Hr, LinkReference, OrderedList, Paragraph, Raw, UnorderedList,
 };
 use parser::Span::{Break, Code, Emphasis, Image, Link, ReferenceLink, Strong, Text};
 use parser::{ListItem, OrderedListType, Span};
@@ -12,9 +12,11 @@ fn slugify(elements: &[Span]) -> String {
     for el in elements {
         let next = match *el {
             Break => "".to_owned(),
-            Text(ref text) | Link(ref text, _, _) | ReferenceLink(ref text, _) | Image(ref text, _, _) | Code(ref text) => {
-                text.trim().replace(" ", "_").to_lowercase().to_owned()
-            }
+            Text(ref text)
+            | Link(ref text, _, _)
+            | ReferenceLink(ref text, _)
+            | Image(ref text, _, _)
+            | Code(ref text) => text.trim().replace(" ", "_").to_lowercase().to_owned(),
             Strong(ref content) | Emphasis(ref content) => slugify(content),
         };
         if !ret.is_empty() {
@@ -30,8 +32,10 @@ pub fn to_html(blocks: &[Block]) -> String {
     let mut references: Vec<(&str, &str, &Option<String>)> = vec![];
     for block in blocks.iter() {
         match block {
-            LinkReference(ref reference, ref link, ref title) => references.push((reference, link, title)),
-            _ => ()
+            LinkReference(ref reference, ref link, ref title) => {
+                references.push((reference, link, title))
+            }
+            _ => (),
         }
     }
 
@@ -43,7 +47,9 @@ pub fn to_html(blocks: &[Block]) -> String {
             Blockquote(ref elements) => format_blockquote(elements),
             CodeBlock(ref lang, ref elements) => format_codeblock(lang, elements),
             UnorderedList(ref elements) => format_unordered_list(&references, elements),
-            OrderedList(ref elements, ref num_type) => format_ordered_list(&references, elements, num_type),
+            OrderedList(ref elements, ref num_type) => {
+                format_ordered_list(&references, elements, num_type)
+            }
             LinkReference(_, _, _) => String::new(),
             Raw(ref elements) => elements.to_owned(),
             Hr => format!("<hr>"),
@@ -84,11 +90,7 @@ fn format_spans(references: &[(&str, &str, &Option<String>)], elements: &[Span])
                                 &escape(text)
                             );
                         } else {
-                            matched = format!(
-                                "<a href='{}'>{}</a>",
-                                &escape(url),
-                                &escape(text)
-                            );
+                            matched = format!("<a href='{}'>{}</a>", &escape(url), &escape(text));
                         }
                     }
                 }
@@ -98,7 +100,7 @@ fn format_spans(references: &[(&str, &str, &Option<String>)], elements: &[Span])
                 } else {
                     matched
                 }
-            },
+            }
             Image(ref text, ref url, None) => {
                 format!("<img src='{}' alt='{}' />", &escape(url), &escape(text))
             }
@@ -109,7 +111,9 @@ fn format_spans(references: &[(&str, &str, &Option<String>)], elements: &[Span])
                 &escape(text)
             ),
             Emphasis(ref content) => format!("<em>{}</em>", format_spans(references, content)),
-            Strong(ref content) => format!("<strong>{}</strong>", format_spans(references, content)),
+            Strong(ref content) => {
+                format!("<strong>{}</strong>", format_spans(references, content))
+            }
         };
         ret.push_str(&next)
     }
@@ -124,7 +128,12 @@ fn escape(text: &str) -> String {
         .replace(">", "&gt;")
 }
 
-fn format_list(references: &[(&str, &str, &Option<String>)], elements: &[ListItem], start_tag: &str, end_tag: &str) -> String {
+fn format_list(
+    references: &[(&str, &str, &Option<String>)],
+    elements: &[ListItem],
+    start_tag: &str,
+    end_tag: &str,
+) -> String {
     let mut ret = String::new();
     for list_item in elements {
         let mut content = String::new();
@@ -140,12 +149,24 @@ fn format_list(references: &[(&str, &str, &Option<String>)], elements: &[ListIte
     format!("<{}>{}</{}>\n\n", start_tag, ret, end_tag)
 }
 
-fn format_unordered_list(references: &[(&str, &str, &Option<String>)], elements: &[ListItem]) -> String {
+fn format_unordered_list(
+    references: &[(&str, &str, &Option<String>)],
+    elements: &[ListItem],
+) -> String {
     format_list(references, elements, "ul", "ul")
 }
 
-fn format_ordered_list(references: &[(&str, &str, &Option<String>)], elements: &[ListItem], num_type: &OrderedListType) -> String {
-    format_list(references, elements, &format!("ol type=\"{}\"", num_type.0), "ol")
+fn format_ordered_list(
+    references: &[(&str, &str, &Option<String>)],
+    elements: &[ListItem],
+    num_type: &OrderedListType,
+) -> String {
+    format_list(
+        references,
+        elements,
+        &format!("ol type=\"{}\"", num_type.0),
+        "ol",
+    )
 }
 
 fn format_codeblock(lang: &Option<String>, elements: &str) -> String {
@@ -168,7 +189,11 @@ fn format_paragraph(references: &[(&str, &str, &Option<String>)], elements: &[Sp
     format!("<p>{}</p>\n\n", format_spans(references, elements))
 }
 
-fn format_header(references: &[(&str, &str, &Option<String>)], elements: &[Span], level: usize) -> String {
+fn format_header(
+    references: &[(&str, &str, &Option<String>)],
+    elements: &[Span],
+    level: usize,
+) -> String {
     format!(
         "<h{} id='{}'>{}</h{}>\n\n",
         level,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,9 +2,8 @@
 #![crate_name = "markdown"]
 #![deny(missing_docs)]
 // #![deny(warnings)]
-
-#![cfg_attr(feature="clippy", feature(plugin))]
-#![cfg_attr(feature="clippy", plugin(clippy))]
+#![cfg_attr(feature = "clippy", feature(plugin))]
+#![cfg_attr(feature = "clippy", plugin(clippy))]
 
 extern crate regex;
 
@@ -15,12 +14,12 @@ extern crate pipeline;
 extern crate lazy_static;
 
 use std::fs::File;
-use std::path::Path;
 use std::io::{self, Read};
+use std::path::Path;
 
-mod parser;
-mod markdown_generator;
 mod html;
+mod markdown_generator;
+mod parser;
 
 pub use parser::{Block, ListItem, Span};
 
@@ -42,7 +41,7 @@ pub fn generate_markdown(x: Vec<Block>) -> String {
 
 /// Opens a file and converts its contents to HTML
 pub fn file_to_html(path: &Path) -> io::Result<String> {
-    let mut file =File::open(path)?;
+    let mut file = File::open(path)?;
 
     let mut text = String::new();
     file.read_to_string(&mut text)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 //! A crate for parsing Markdown in Rust
-#![crate_name = "markdown"]
+#![crate_name = "markly"]
 #![deny(missing_docs)]
 // #![deny(warnings)]
 #![cfg_attr(feature = "clippy", feature(plugin))]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 extern crate markdown;
 
-use std::path::Path;
 use std::env;
+use std::path::Path;
 
 fn main() {
     let args: Vec<String> = env::args().collect();

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-extern crate markdown;
+extern crate markly;
 
 use std::env;
 use std::path::Path;
@@ -9,5 +9,5 @@ fn main() {
     let path = Path::new(&args[1]);
     // let display = path.display();
 
-    println!("{}", markdown::file_to_html(&path).unwrap());
+    println!("{}", markly::file_to_html(&path).unwrap());
 }

--- a/src/markdown_generator/mod.rs
+++ b/src/markdown_generator/mod.rs
@@ -36,6 +36,8 @@ fn gen_block(b: Block) -> String {
         // [TODO]: Ordered list generation - 2017-12-10 10:12pm
         OrderedList(_x, _num_type) => unimplemented!("Generate ordered list"),
         UnorderedList(x) => generate_from_li(x),
+        // TODO: Link References generation - 2020-05-11
+        LinkReference(_reference, _link, _title) => unimplemented!("Generate link reference"),
         Raw(x) => x,
         Hr => "\n\n".to_string(),
     }
@@ -49,6 +51,8 @@ fn gen_span(s: Span) -> String {
         Code(x) => format!("`{}`", x),
         Link(a, b, None) => format!("[{}]({})", a, b),
         Link(a, b, Some(c)) => format!("[{}]({} \"{}\")", a, b, c),
+        // TODO: Reference Link generation - 2020-05-11
+        ReferenceLink(_a, _b) => unimplemented!("Generate reference link"),
         Image(a, b, None) => format!("![{}]({})", a, b),
         Image(a, b, Some(c)) => format!("![{}]({} \"{}\")", a, b, c),
         Emphasis(x) => format!("*{}*", generate_from_spans(x)),

--- a/src/markdown_generator/mod.rs
+++ b/src/markdown_generator/mod.rs
@@ -1,73 +1,86 @@
 use super::{Block, ListItem, Span};
 
-trait JoinHelper<I> where I : Iterator {
-    fn j(self, sep:&'static str) -> String;
+trait JoinHelper<I>
+where
+    I: Iterator,
+{
+    fn j(self, sep: &'static str) -> String;
 }
 
-impl<I> JoinHelper<I> for I where I : Iterator<Item=String> {
-    fn j(self, sep:&'static str) -> String {
+impl<I> JoinHelper<I> for I
+where
+    I: Iterator<Item = String>,
+{
+    fn j(self, sep: &'static str) -> String {
         self.collect::<Vec<String>>().join(sep)
     }
 }
 
-fn gen_block(b : Block) -> String {
+fn gen_block(b: Block) -> String {
     use Block::*;
     match b {
-        Header(s, level) => format!("{} {}",
-                ::std::iter::repeat("#".to_string()).take(level).j(""),
-                generate_from_spans(s)
-                ),
+        Header(s, level) => format!(
+            "{} {}",
+            ::std::iter::repeat("#".to_string()).take(level).j(""),
+            generate_from_spans(s)
+        ),
         Paragraph(s) => generate_from_spans(s),
-        Blockquote(bb) => generate(bb).lines().map(|x|format!("> {}", x)).j("\n"),
+        Blockquote(bb) => generate(bb).lines().map(|x| format!("> {}", x)).j("\n"),
         CodeBlock(lang, x) => {
             if lang.is_none() {
-                x.lines().map(|x|format!("    {}",x)).j("\n")
+                x.lines().map(|x| format!("    {}", x)).j("\n")
             } else {
                 format!("```{}\n{}```", lang.unwrap(), x)
             }
-        },
+        }
         // [TODO]: Ordered list generation - 2017-12-10 10:12pm
-        OrderedList(_x,_num_type) => unimplemented!("Generate ordered list"),
+        OrderedList(_x, _num_type) => unimplemented!("Generate ordered list"),
         UnorderedList(x) => generate_from_li(x),
         Raw(x) => x,
         Hr => "\n\n".to_string(),
     }
 }
 
-fn gen_span(s : Span) -> String {
+fn gen_span(s: Span) -> String {
     use Span::*;
     match s {
         Break => "  \n".to_string(),
         Text(x) => x,
-        Code(x) => format!("`{}`",x),
-        Link(a, b, None)     => format!("[{}]({})", a, b),
-        Link(a, b, Some(c))  => format!("[{}]({} \"{}\")", a, b, c),
-        Image(a, b, None)    => format!("![{}]({})", a, b),
+        Code(x) => format!("`{}`", x),
+        Link(a, b, None) => format!("[{}]({})", a, b),
+        Link(a, b, Some(c)) => format!("[{}]({} \"{}\")", a, b, c),
+        Image(a, b, None) => format!("![{}]({})", a, b),
         Image(a, b, Some(c)) => format!("![{}]({} \"{}\")", a, b, c),
-        Emphasis(x) => format!("*{}*",   generate_from_spans(x)),
-        Strong(x)   => format!("**{}**", generate_from_spans(x)),
+        Emphasis(x) => format!("*{}*", generate_from_spans(x)),
+        Strong(x) => format!("**{}**", generate_from_spans(x)),
     }
 }
-
 
 fn generate_from_li(data: Vec<ListItem>) -> String {
     use ListItem::*;
 
-    data.into_iter().map(|x|format!("* {}", match x {
-        Simple(x) => generate_from_spans(x),
-        Paragraph(x) => format!("{}\n",
-                            generate(x)
+    data.into_iter()
+        .map(|x| {
+            format!(
+                "* {}",
+                match x {
+                    Simple(x) => generate_from_spans(x),
+                    Paragraph(x) => format!(
+                        "{}\n",
+                        generate(x)
                             .lines()
                             .enumerate()
-                            .map(|(i, x)|
-                                if i == 0 {
-                                    x.to_string()
-                                } else {
-                                    format!("    {}", x)
-                                }
-                            ).j("\n")
-                        ),
-    })).j("\n")
+                            .map(|(i, x)| if i == 0 {
+                                x.to_string()
+                            } else {
+                                format!("    {}", x)
+                            })
+                            .j("\n")
+                    ),
+                }
+            )
+        })
+        .j("\n")
 }
 
 fn generate_from_spans(data: Vec<Span>) -> String {

--- a/src/markdown_generator/mod.rs
+++ b/src/markdown_generator/mod.rs
@@ -19,7 +19,13 @@ fn gen_block(b : Block) -> String {
                 ),
         Paragraph(s) => generate_from_spans(s),
         Blockquote(bb) => generate(bb).lines().map(|x|format!("> {}", x)).j("\n"),
-        CodeBlock(x) => x.lines().map(|x|format!("    {}",x)).j("\n"),
+        CodeBlock(lang, x) => {
+            if lang.is_none() {
+                x.lines().map(|x|format!("    {}",x)).j("\n")
+            } else {
+                format!("```{}\n{}```", lang.unwrap(), x)
+            }
+        },
         //OrderedList(Vec<ListItem>),
         UnorderedList(x) => generate_from_li(x),
         Raw(x) => x,

--- a/src/parser/block/atx_header.rs
+++ b/src/parser/block/atx_header.rs
@@ -1,18 +1,23 @@
-use regex::Regex;
+use parser::span::parse_spans;
 use parser::Block;
 use parser::Block::Header;
-use parser::span::parse_spans;
+use regex::Regex;
 
 pub fn parse_atx_header(lines: &[&str]) -> Option<(Block, usize)> {
     lazy_static! {
-        static ref ATX_HEADER_RE :Regex = Regex::new(r"^(?P<level>#{1,6})\s(?P<text>.*?)(?:\s#*)?$").unwrap();
+        static ref ATX_HEADER_RE: Regex =
+            Regex::new(r"^(?P<level>#{1,6})\s(?P<text>.*?)(?:\s#*)?$").unwrap();
     }
 
     if ATX_HEADER_RE.is_match(lines[0]) {
         let caps = ATX_HEADER_RE.captures(lines[0]).unwrap();
-        return Some((Header(parse_spans(caps.name("text").unwrap().as_str()),
-                            caps.name("level").unwrap().as_str().len()),
-                     1));
+        return Some((
+            Header(
+                parse_spans(caps.name("text").unwrap().as_str()),
+                caps.name("level").unwrap().as_str().len(),
+            ),
+            1,
+        ));
     }
     None
 }
@@ -25,39 +30,59 @@ mod test {
 
     #[test]
     fn finds_atx_header() {
-        assert_eq!(parse_atx_header(&vec!["### Test", "testtest"]).unwrap(),
-                   (Header(vec![Text("Test".to_owned())], 3), 1));
+        assert_eq!(
+            parse_atx_header(&vec!["### Test", "testtest"]).unwrap(),
+            (Header(vec![Text("Test".to_owned())], 3), 1)
+        );
 
-        assert_eq!(parse_atx_header(&vec!["# Test", "testtest"]).unwrap(),
-                   (Header(vec![Text("Test".to_owned())], 1), 1));
+        assert_eq!(
+            parse_atx_header(&vec!["# Test", "testtest"]).unwrap(),
+            (Header(vec![Text("Test".to_owned())], 1), 1)
+        );
 
-        assert_eq!(parse_atx_header(&vec!["###### Test", "testtest"]).unwrap(),
-                   (Header(vec![Text("Test".to_owned())], 6), 1));
+        assert_eq!(
+            parse_atx_header(&vec!["###### Test", "testtest"]).unwrap(),
+            (Header(vec![Text("Test".to_owned())], 6), 1)
+        );
 
-        assert_eq!(parse_atx_header(&vec!["### Test and a pretty long sentence", "testtest"])
-                       .unwrap(),
-                   (Header(vec![Text("Test and a pretty long sentence".to_owned())], 3),
-                    1));
+        assert_eq!(
+            parse_atx_header(&vec!["### Test and a pretty long sentence", "testtest"]).unwrap(),
+            (
+                Header(vec![Text("Test and a pretty long sentence".to_owned())], 3),
+                1
+            )
+        );
     }
 
     #[test]
     fn ignores_closing_hashes() {
-        assert_eq!(parse_atx_header(&vec!["### Test ###", "testtest"]).unwrap(),
-                   (Header(vec![Text("Test".to_owned())], 3), 1));
+        assert_eq!(
+            parse_atx_header(&vec!["### Test ###", "testtest"]).unwrap(),
+            (Header(vec![Text("Test".to_owned())], 3), 1)
+        );
 
-        assert_eq!(parse_atx_header(&vec!["# Test #", "testtest"]).unwrap(),
-                   (Header(vec![Text("Test".to_owned())], 1), 1));
+        assert_eq!(
+            parse_atx_header(&vec!["# Test #", "testtest"]).unwrap(),
+            (Header(vec![Text("Test".to_owned())], 1), 1)
+        );
 
-        assert_eq!(parse_atx_header(&vec!["###### Test ##", "testtest"]).unwrap(),
-                   (Header(vec![Text("Test".to_owned())], 6), 1));
+        assert_eq!(
+            parse_atx_header(&vec!["###### Test ##", "testtest"]).unwrap(),
+            (Header(vec![Text("Test".to_owned())], 6), 1)
+        );
 
-        assert_eq!(parse_atx_header(&vec!["### Test and a pretty long sentence #########",
-                                          "testtest"])
-                       .unwrap(),
-                   (Header(vec![Text("Test and a pretty long sentence".to_owned())], 3),
-                    1));
+        assert_eq!(
+            parse_atx_header(&vec![
+                "### Test and a pretty long sentence #########",
+                "testtest"
+            ])
+            .unwrap(),
+            (
+                Header(vec![Text("Test and a pretty long sentence".to_owned())], 3),
+                1
+            )
+        );
     }
-
 
     #[test]
     fn no_false_positives() {

--- a/src/parser/block/blockquote.rs
+++ b/src/parser/block/blockquote.rs
@@ -36,7 +36,8 @@ pub fn parse_blockquote(lines: &[&str]) -> Option<(Block, usize)> {
             Some('>') => match chars.next() {
                 Some(' ') => 2,
                 _ => 1,
-            }, _ => 0,
+            },
+            _ => 0,
         };
         if i > 0 {
             content.push('\n');
@@ -85,7 +86,9 @@ mod test {
 
     #[test]
     fn no_early_matching() {
-        assert_eq!(parse_blockquote(&vec!["Hello", "> A citation", "> is good", "", "whatever"]),
-                   None);
+        assert_eq!(
+            parse_blockquote(&vec!["Hello", "> A citation", "> is good", "", "whatever"]),
+            None
+        );
     }
 }

--- a/src/parser/block/code_block.rs
+++ b/src/parser/block/code_block.rs
@@ -82,7 +82,10 @@ mod test {
 
         assert_eq!(
             parse_code_block(&vec!["```testlang", "Test", "this", "```"]).unwrap(),
-            ((CodeBlock(Some(String::from("testlang")), "Test\nthis".to_owned()), 4))
+            ((
+                CodeBlock(Some(String::from("testlang")), "Test\nthis".to_owned()),
+                4
+            ))
         );
     }
 

--- a/src/parser/block/code_block.rs
+++ b/src/parser/block/code_block.rs
@@ -1,40 +1,65 @@
-use regex::Regex;
 use parser::Block;
 use parser::Block::CodeBlock;
+use regex::Regex;
 
 pub fn parse_code_block(lines: &[&str]) -> Option<(Block, usize)> {
     lazy_static! {
-        static ref CODE_BLOCK_SPACES :Regex = Regex::new(r"^ {4}").unwrap();
-        static ref CODE_BLOCK_TABS :Regex = Regex::new(r"^\t").unwrap();
+        static ref CODE_BLOCK_SPACES: Regex = Regex::new(r"^ {4}").unwrap();
+        static ref CODE_BLOCK_TABS: Regex = Regex::new(r"^\t").unwrap();
+        static ref CODE_BLOCK_BACKTICKS: Regex = Regex::new(r"```").unwrap();
     }
 
     let mut content = String::new();
-    let mut i = 0;
+    let mut lang: Option<String> = None;
+    let mut line_number = 0;
+    let mut backtick_opened = false;
+    let mut backtick_closed = false;
+
     for line in lines {
-        if CODE_BLOCK_SPACES.is_match(line) {
-            if i > 0 && !content.is_empty() {
+        if !backtick_opened && CODE_BLOCK_SPACES.is_match(line) {
+            if line_number > 0 && !content.is_empty() {
                 content.push('\n');
             }
             // remove top-level spaces
             content.push_str(&line[4..line.len()]);
-            i += 1;
-        } else if CODE_BLOCK_TABS.is_match(line) {
-            if i > 0 && !content.is_empty() {
+            line_number += 1;
+        } else if !backtick_opened && CODE_BLOCK_TABS.is_match(line) {
+            if line_number > 0 && !content.is_empty() {
                 content.push('\n');
             }
 
-            if !(i == 0 && line.trim().is_empty()) {
+            if !(line_number == 0 && line.trim().is_empty()) {
                 // remove top-level spaces
                 content.push_str(&line[1..line.len()]);
             }
-            i += 1;
+            line_number += 1;
+        } else if CODE_BLOCK_BACKTICKS.is_match(line) {
+            line_number += 1;
+
+            if !backtick_opened && !(line_number == 0 && line.get(3..).is_some()) {
+                lang = Some(String::from(line.get(3..).unwrap()));
+                backtick_opened = true;
+            } else if backtick_opened {
+                backtick_closed = true;
+                break;
+            }
+        } else if backtick_opened {
+            content.push_str(line);
+            content.push('\n');
+
+            line_number += 1;
         } else {
             break;
         }
     }
-    if i > 0 {
-        return Some((CodeBlock(content.trim_matches('\n').to_owned()), i));
+
+    if line_number > 0 && ((backtick_opened && backtick_closed) || !backtick_opened) {
+        return Some((
+            CodeBlock(lang, content.trim_matches('\n').to_owned()),
+            line_number,
+        ));
     }
+
     None
 }
 
@@ -45,17 +70,28 @@ mod test {
 
     #[test]
     fn finds_code_block() {
-        assert_eq!(parse_code_block(&vec!["    Test"]).unwrap(),
-                   ((CodeBlock("Test".to_owned()), 1)));
+        assert_eq!(
+            parse_code_block(&vec!["    Test"]).unwrap(),
+            ((CodeBlock(None, "Test".to_owned()), 1))
+        );
 
-        assert_eq!(parse_code_block(&vec!["    Test", "    this"]).unwrap(),
-                   ((CodeBlock("Test\nthis".to_owned()), 2)));
+        assert_eq!(
+            parse_code_block(&vec!["    Test", "    this"]).unwrap(),
+            ((CodeBlock(None, "Test\nthis".to_owned()), 2))
+        );
+
+        assert_eq!(
+            parse_code_block(&vec!["```testlang", "Test", "this", "```"]).unwrap(),
+            ((CodeBlock(Some(String::from("testlang")), "Test\nthis".to_owned()), 4))
+        );
     }
 
     #[test]
     fn knows_when_to_stop() {
-        assert_eq!(parse_code_block(&vec!["    Test", "    this", "stuff", "    now"]).unwrap(),
-                   ((CodeBlock("Test\nthis".to_owned()), 2)));
+        assert_eq!(
+            parse_code_block(&vec!["    Test", "    this", "stuff", "    now"]).unwrap(),
+            ((CodeBlock(None, "Test\nthis".to_owned()), 2))
+        );
     }
 
     #[test]
@@ -65,7 +101,9 @@ mod test {
 
     #[test]
     fn no_early_matching() {
-        assert_eq!(parse_code_block(&vec!["Test", "    this", "stuff", "    now"]),
-                   None);
+        assert_eq!(
+            parse_code_block(&vec!["Test", "    this", "stuff", "    now"]),
+            None
+        );
     }
 }

--- a/src/parser/block/hr.rs
+++ b/src/parser/block/hr.rs
@@ -1,10 +1,10 @@
-use regex::Regex;
 use parser::Block;
 use parser::Block::Hr;
+use regex::Regex;
 
 pub fn parse_hr(lines: &[&str]) -> Option<(Block, usize)> {
     lazy_static! {
-        static ref HORIZONTAL_RULE :Regex = Regex::new(r"^(===+)$|^(---+)$").unwrap();
+        static ref HORIZONTAL_RULE: Regex = Regex::new(r"^(===+)$|^(---+)$").unwrap();
     }
 
     if HORIZONTAL_RULE.is_match(lines[0]) {
@@ -22,14 +22,18 @@ mod test {
     fn finds_hr() {
         assert_eq!(parse_hr(&vec!["-------"]).unwrap(), (Hr, 1));
         assert_eq!(parse_hr(&vec!["---"]).unwrap(), (Hr, 1));
-        assert_eq!(parse_hr(&vec!["----------------------------"]).unwrap(),
-                   (Hr, 1));
+        assert_eq!(
+            parse_hr(&vec!["----------------------------"]).unwrap(),
+            (Hr, 1)
+        );
         assert_eq!(parse_hr(&vec!["-------", "abc"]).unwrap(), (Hr, 1));
 
         assert_eq!(parse_hr(&vec!["======="]).unwrap(), (Hr, 1));
         assert_eq!(parse_hr(&vec!["==="]).unwrap(), (Hr, 1));
-        assert_eq!(parse_hr(&vec!["============================"]).unwrap(),
-                   (Hr, 1));
+        assert_eq!(
+            parse_hr(&vec!["============================"]).unwrap(),
+            (Hr, 1)
+        );
         assert_eq!(parse_hr(&vec!["=======", "abc"]).unwrap(), (Hr, 1));
     }
 

--- a/src/parser/block/link_reference.rs
+++ b/src/parser/block/link_reference.rs
@@ -5,7 +5,8 @@ use regex::Regex;
 pub fn parse_link_reference(lines: &[&str]) -> Option<(Block, usize)> {
     lazy_static! {
         static ref LINK_REFERENCE: Regex =
-            Regex::new("^\\[(?P<reference>.*?)\\]:\\s(?P<url>.*?)(?:\\s\"(?P<title>.*?)\")?$").unwrap();
+            Regex::new("^\\[(?P<reference>.*?)\\]:\\s(?P<url>.*?)(?:\\s\"(?P<title>.*?)\")?$")
+                .unwrap();
     }
 
     if LINK_REFERENCE.is_match(lines[0]) {
@@ -55,7 +56,14 @@ mod test {
     fn finds_link_reference() {
         assert_eq!(
             parse_link_reference(&vec!["[ref]: link \"title\"", "next line"]).unwrap(),
-            (LinkReference("ref".to_owned(), "link".to_owned(), Some("title".to_owned())), 1)
+            (
+                LinkReference(
+                    "ref".to_owned(),
+                    "link".to_owned(),
+                    Some("title".to_owned())
+                ),
+                1
+            )
         );
 
         assert_eq!(
@@ -71,10 +79,7 @@ mod test {
             None
         );
 
-        assert_eq!(
-            parse_link_reference(&vec!["[ref]: ", "next line"]),
-            None
-        );
+        assert_eq!(parse_link_reference(&vec!["[ref]: ", "next line"]), None);
 
         assert_eq!(
             parse_link_reference(&vec!["ahh [ref]: link \"title\"", "next line"]),

--- a/src/parser/block/link_reference.rs
+++ b/src/parser/block/link_reference.rs
@@ -1,0 +1,84 @@
+use parser::Block;
+use parser::Block::LinkReference;
+use regex::Regex;
+
+pub fn parse_link_reference(lines: &[&str]) -> Option<(Block, usize)> {
+    lazy_static! {
+        static ref LINK_REFERENCE: Regex =
+            Regex::new("^\\[(?P<reference>.*?)\\]:\\s(?P<url>.*?)(?:\\s\"(?P<title>.*?)\")?$").unwrap();
+    }
+
+    if LINK_REFERENCE.is_match(lines[0]) {
+        let caps = LINK_REFERENCE.captures(lines[0]).unwrap();
+        let text = if let Some(mat) = caps.name("reference") {
+            if mat.as_str().is_empty() {
+                //Don't parse a link ref without a ref
+                return None;
+            }
+
+            mat.as_str().to_owned()
+        } else {
+            //Don't parse a link reference without a reference
+            return None;
+        };
+
+        let url = if let Some(mat) = caps.name("url") {
+            if mat.as_str().is_empty() {
+                //Don't parse a link ref without a link
+                return None;
+            }
+
+            mat.as_str().to_owned()
+        } else {
+            //Don't parse a link reference without a link
+            return None;
+        };
+
+        let title = if let Some(mat) = caps.name("title") {
+            Some(mat.as_str().to_owned())
+        } else {
+            //Titles are optional
+            None
+        };
+
+        return Some((LinkReference(text, url, title), 1));
+    }
+    None
+}
+
+#[cfg(test)]
+mod test {
+    use super::parse_link_reference;
+    use parser::Block::LinkReference;
+
+    #[test]
+    fn finds_link_reference() {
+        assert_eq!(
+            parse_link_reference(&vec!["[ref]: link \"title\"", "next line"]).unwrap(),
+            (LinkReference("ref".to_owned(), "link".to_owned(), Some("title".to_owned())), 1)
+        );
+
+        assert_eq!(
+            parse_link_reference(&vec!["[ref]: link", "next line"]).unwrap(),
+            (LinkReference("ref".to_owned(), "link".to_owned(), None), 1)
+        );
+    }
+
+    #[test]
+    fn no_false_positives() {
+        assert_eq!(
+            parse_link_reference(&vec!["[]: link \"title\"", "next line"]),
+            None
+        );
+
+        assert_eq!(
+            parse_link_reference(&vec!["[ref]: ", "next line"]),
+            None
+        );
+
+        assert_eq!(
+            parse_link_reference(&vec!["ahh [ref]: link \"title\"", "next line"]),
+            None
+        );
+    }
+}

--- a/src/parser/block/mod.rs
+++ b/src/parser/block/mod.rs
@@ -7,18 +7,18 @@ mod atx_header;
 mod blockquote;
 mod code_block;
 mod hr;
+mod link_reference;
 mod ordered_list;
 mod setext_header;
 mod unordered_list;
-mod link_reference;
 use self::atx_header::parse_atx_header;
 use self::blockquote::parse_blockquote;
 use self::code_block::parse_code_block;
 use self::hr::parse_hr;
+use self::link_reference::parse_link_reference;
 use self::ordered_list::parse_ordered_list;
 use self::setext_header::parse_setext_header;
 use self::unordered_list::parse_unordered_list;
-use self::link_reference::parse_link_reference;
 
 pub fn parse_blocks(md: &str) -> Vec<Block> {
     let mut blocks = vec![];
@@ -88,7 +88,7 @@ fn parse_block(lines: &[&str]) -> Option<(Block, usize)> {
 #[cfg(test)]
 mod test {
     use super::parse_blocks;
-    use parser::Block::{Blockquote, CodeBlock, Header, Hr, Paragraph, LinkReference};
+    use parser::Block::{Blockquote, CodeBlock, Header, Hr, LinkReference, Paragraph};
     use parser::Span::Text;
 
     #[test]

--- a/src/parser/block/mod.rs
+++ b/src/parser/block/mod.rs
@@ -1,35 +1,35 @@
+use parser::span::parse_spans;
 use parser::Block;
 use parser::Block::Paragraph;
-use parser::Span::{Text, Break};
-use parser::span::parse_spans;
+use parser::Span::{Break, Text};
 
 mod atx_header;
-mod setext_header;
-mod hr;
-mod code_block;
 mod blockquote;
-mod unordered_list;
+mod code_block;
+mod hr;
 mod ordered_list;
+mod setext_header;
+mod unordered_list;
 use self::atx_header::parse_atx_header;
-use self::setext_header::parse_setext_header;
-use self::hr::parse_hr;
-use self::code_block::parse_code_block;
 use self::blockquote::parse_blockquote;
-use self::unordered_list::parse_unordered_list;
+use self::code_block::parse_code_block;
+use self::hr::parse_hr;
 use self::ordered_list::parse_ordered_list;
+use self::setext_header::parse_setext_header;
+use self::unordered_list::parse_unordered_list;
 
-pub fn parse_blocks (md : &str) -> Vec<Block> {
+pub fn parse_blocks(md: &str) -> Vec<Block> {
     let mut blocks = vec![];
     let mut t = vec![];
-    let lines : Vec<&str> = md.lines().collect();
+    let lines: Vec<&str> = md.lines().collect();
     let mut i = 0;
     while i < lines.len() {
-        match parse_block(&lines[i .. lines.len()]){
+        match parse_block(&lines[i..lines.len()]) {
             // if a block is found
             Some((block, consumed_lines)) => {
                 // the current paragraph has ended,
                 // push it to our blocks
-                if !t.is_empty(){
+                if !t.is_empty() {
                     blocks.push(Paragraph(t));
                     t = Vec::new();
                 }
@@ -38,9 +38,8 @@ pub fn parse_blocks (md : &str) -> Vec<Block> {
             }
             // no known element, let's make this a paragraph
             None => {
-
                 // empty linebreak => new paragraph
-                if lines[i].is_empty() && !t.is_empty(){
+                if lines[i].is_empty() && !t.is_empty() {
                     blocks.push(Paragraph(t));
                     t = Vec::new();
                 }
@@ -50,10 +49,10 @@ pub fn parse_blocks (md : &str) -> Vec<Block> {
                 // add a whitespace between linebreaks
                 // except when we have a break element or nothing
                 match (t.last(), spans.first()) {
-                    (Some(&Break), _) => {},
-                    (_, None) => {},
-                    (None, _) => {},
-                    _ => t.push(Text(" ".to_owned()))
+                    (Some(&Break), _) => {}
+                    (_, None) => {}
+                    (None, _) => {}
+                    _ => t.push(Text(" ".to_owned())),
                 }
 
                 t.extend_from_slice(&spans);
@@ -61,29 +60,29 @@ pub fn parse_blocks (md : &str) -> Vec<Block> {
             }
         }
     }
-    if !t.is_empty(){
+    if !t.is_empty() {
         blocks.push(Paragraph(t));
     }
     blocks
 }
 
-fn parse_block (lines: &[&str]) -> Option<(Block, usize)>{
+fn parse_block(lines: &[&str]) -> Option<(Block, usize)> {
     pipe_opt!(
-        lines
-        => parse_hr
-        => parse_atx_header
-        => parse_setext_header
-        => parse_code_block
-        => parse_blockquote
-        => parse_unordered_list
-        => parse_ordered_list
-        )
+    lines
+    => parse_hr
+    => parse_atx_header
+    => parse_setext_header
+    => parse_code_block
+    => parse_blockquote
+    => parse_unordered_list
+    => parse_ordered_list
+    )
 }
 
 #[cfg(test)]
 mod test {
     use super::parse_blocks;
-    use parser::Block::{Header, Hr, CodeBlock, Paragraph, Blockquote};
+    use parser::Block::{Blockquote, CodeBlock, Header, Hr, Paragraph};
     use parser::Span::Text;
 
     #[test]
@@ -91,7 +90,7 @@ mod test {
         assert_eq!(
             parse_blocks("### Test"),
             vec![Header(vec![Text("Test".to_owned())], 3)]
-            );
+        );
     }
 
     #[test]
@@ -99,23 +98,17 @@ mod test {
         assert_eq!(
             parse_blocks("Test\n-------"),
             vec![Header(vec![Text("Test".to_owned())], 2)]
-            );
+        );
         assert_eq!(
             parse_blocks("Test\n======="),
             vec![Header(vec![Text("Test".to_owned())], 1)]
-            );
+        );
     }
 
     #[test]
     fn finds_hr() {
-        assert_eq!(
-            parse_blocks("-------"),
-            vec![Hr]
-            );
-        assert_eq!(
-            parse_blocks("======="),
-            vec![Hr]
-            );
+        assert_eq!(parse_blocks("-------"), vec![Hr]);
+        assert_eq!(parse_blocks("======="), vec![Hr]);
     }
 
     #[test]
@@ -127,7 +120,10 @@ mod test {
 
         assert_eq!(
             parse_blocks("```\nthis is code\nand this as well\n```"),
-            vec![CodeBlock(Some(String::new()), "this is code\nand this as well".to_owned())]
+            vec![CodeBlock(
+                Some(String::new()),
+                "this is code\nand this as well".to_owned()
+            )]
         );
     }
 
@@ -135,31 +131,41 @@ mod test {
     fn finds_blockquotes() {
         assert_eq!(
             parse_blocks("> One Paragraph\n>\n> ## H2 \n>\n"),
-            vec![Blockquote(vec![Paragraph(vec![Text("One Paragraph".to_owned())]), Header(vec![Text("H2".to_owned())], 2)])]
-            );
+            vec![Blockquote(vec![
+                Paragraph(vec![Text("One Paragraph".to_owned())]),
+                Header(vec![Text("H2".to_owned())], 2)
+            ])]
+        );
 
         assert_eq!(
             parse_blocks("> One Paragraph\n>\n> > Another blockquote\n>\n"),
-            vec![Blockquote(vec![Paragraph(vec![Text("One Paragraph".to_owned())]),
-            Blockquote(vec![Paragraph(vec![Text("Another blockquote".to_owned())])])])]
-            );
+            vec![Blockquote(vec![
+                Paragraph(vec![Text("One Paragraph".to_owned())]),
+                Blockquote(vec![Paragraph(vec![Text("Another blockquote".to_owned())])])
+            ])]
+        );
 
         assert_eq!(
             parse_blocks("> > One Paragraph\n> >\n> > Another blockquote\n>\n"),
-            vec![Blockquote(vec![Blockquote(vec![Paragraph(vec![Text("One Paragraph".to_owned())]),
-            Paragraph(vec![Text("Another blockquote".to_owned())])])])]
-            );
+            vec![Blockquote(vec![Blockquote(vec![
+                Paragraph(vec![Text("One Paragraph".to_owned())]),
+                Paragraph(vec![Text("Another blockquote".to_owned())])
+            ])])]
+        );
 
         assert_eq!(
             parse_blocks("> One Paragraph, just > text \n>\n"),
-            vec![Blockquote(vec![Paragraph(vec![Text("One Paragraph, just > text".to_owned())])])]
-            );
+            vec![Blockquote(vec![Paragraph(vec![Text(
+                "One Paragraph, just > text".to_owned()
+            )])])]
+        );
 
         assert_eq!(
             parse_blocks("> One Paragraph\n>\n> just > text \n>\n"),
-            vec![Blockquote(vec![Paragraph(vec![Text("One Paragraph".to_owned())]),Paragraph(vec![Text("just > text".to_owned())])])]
-            );
+            vec![Blockquote(vec![
+                Paragraph(vec![Text("One Paragraph".to_owned())]),
+                Paragraph(vec![Text("just > text".to_owned())])
+            ])]
+        );
     }
 }
-
-

--- a/src/parser/block/mod.rs
+++ b/src/parser/block/mod.rs
@@ -119,8 +119,13 @@ mod test {
     fn finds_code_block() {
         assert_eq!(
             parse_blocks("    this is code\n    and this as well"),
-            vec![CodeBlock("this is code\nand this as well".to_owned())]
-            );
+            vec![CodeBlock(None, "this is code\nand this as well".to_owned())]
+        );
+
+        assert_eq!(
+            parse_blocks("```\nthis is code\nand this as well\n```"),
+            vec![CodeBlock(Some(String::new()), "this is code\nand this as well".to_owned())]
+        );
     }
 
     #[test]

--- a/src/parser/block/ordered_list.rs
+++ b/src/parser/block/ordered_list.rs
@@ -1,14 +1,15 @@
-use parser::Block;
 use parser::block::parse_blocks;
+use parser::Block;
 use parser::Block::{OrderedList, Paragraph};
-use parser::{ ListItem, OrderedListType };
+use parser::{ListItem, OrderedListType};
 use regex::Regex;
 
-pub fn parse_ordered_list(lines:  &[&str]) -> Option<(Block, usize)> {
+pub fn parse_ordered_list(lines: &[&str]) -> Option<(Block, usize)> {
     lazy_static! {
-        static ref LIST_BEGIN :Regex = Regex::new(r"^(?P<indent> *)(?P<numbering>[0-9.]+|[aAiI]+\.) (?P<content>.*)").unwrap();
-        static ref NEW_PARAGRAPH :Regex = Regex::new(r"^ +").unwrap();
-        static ref INDENTED :Regex = Regex::new(r"^ {0,4}(?P<content>.*)").unwrap();
+        static ref LIST_BEGIN: Regex =
+            Regex::new(r"^(?P<indent> *)(?P<numbering>[0-9.]+|[aAiI]+\.) (?P<content>.*)").unwrap();
+        static ref NEW_PARAGRAPH: Regex = Regex::new(r"^ +").unwrap();
+        static ref INDENTED: Regex = Regex::new(r"^ {0,4}(?P<content>.*)").unwrap();
     }
 
     // if the beginning doesn't match a list don't even bother
@@ -92,8 +93,7 @@ pub fn parse_ordered_list(lines:  &[&str]) -> Option<(Block, usize)> {
 
     if i > 0 {
         let list_num = list_num_opt.unwrap_or("1".to_string());
-        return Some((OrderedList(list_contents,
-                                 OrderedListType( list_num)), i));
+        return Some((OrderedList(list_contents, OrderedListType(list_num)), i));
     }
 
     None
@@ -104,28 +104,38 @@ pub fn parse_ordered_list(lines:  &[&str]) -> Option<(Block, usize)> {
 mod test {
     use super::parse_ordered_list;
     use parser::Block::OrderedList;
-    use parser::OrderedListType;
     use parser::ListItem::Paragraph;
-    fn a_type() -> OrderedListType  { OrderedListType("a".to_string()) }
-    fn A_type() -> OrderedListType  { OrderedListType("A".to_string()) }
-    fn i_type() -> OrderedListType  { OrderedListType("i".to_string()) }
-    fn I_type() -> OrderedListType  { OrderedListType("I".to_string()) }
-    fn n_type() -> OrderedListType  { OrderedListType("1".to_string()) }
+    use parser::OrderedListType;
+    fn a_type() -> OrderedListType {
+        OrderedListType("a".to_string())
+    }
+    fn A_type() -> OrderedListType {
+        OrderedListType("A".to_string())
+    }
+    fn i_type() -> OrderedListType {
+        OrderedListType("i".to_string())
+    }
+    fn I_type() -> OrderedListType {
+        OrderedListType("I".to_string())
+    }
+    fn n_type() -> OrderedListType {
+        OrderedListType("1".to_string())
+    }
 
     #[test]
     fn finds_list() {
         match parse_ordered_list(&vec!["1. A list", "2. is good"]) {
-            Some( (OrderedList(_, ref lt ), 2) ) if lt == &n_type() => (),
+            Some((OrderedList(_, ref lt), 2)) if lt == &n_type() => (),
             x => panic!("Found {:?}", x),
         }
 
         match parse_ordered_list(&vec!["a. A list", "b. is good", "laksjdnflakdsjnf"]) {
-            Some( (OrderedList(_, ref lt ), 3) ) if lt == &a_type() => (),
+            Some((OrderedList(_, ref lt), 3)) if lt == &a_type() => (),
             x => panic!("Found {:?}", x),
         }
 
         match parse_ordered_list(&vec!["A. A list", "B. is good", "laksjdnflakdsjnf"]) {
-            Some( (OrderedList(_, ref lt ), 3) ) if lt == &A_type() => (),
+            Some((OrderedList(_, ref lt), 3)) if lt == &A_type() => (),
             x => panic!("Found {:?}", x),
         }
     }
@@ -133,30 +143,32 @@ mod test {
     #[test]
     fn knows_when_to_stop() {
         match parse_ordered_list(&vec!["i. A list", "ii. is good", "", "laksjdnflakdsjnf"]) {
-            Some( (OrderedList(_, ref lt ), 3) ) if lt == &i_type() => (),
+            Some((OrderedList(_, ref lt), 3)) if lt == &i_type() => (),
             x => panic!("Found {:?}", x),
         }
 
         match parse_ordered_list(&vec!["I. A list", "", "laksjdnflakdsjnf"]) {
-            Some( (OrderedList(_, ref lt), 2) ) if lt == &I_type() => (),
+            Some((OrderedList(_, ref lt), 2)) if lt == &I_type() => (),
             x => panic!("Found {:?}", x),
         }
     }
 
     #[test]
     fn multi_level_list() {
-        match parse_ordered_list(&vec!["1. A list", "     1.1. One point one", "     1.2. One point two"]) {
-            Some( (OrderedList(ref items, ref lt), 3) ) if lt == &n_type() =>
-                match &items[0] {
-                    &Paragraph(ref items) => match &items[1] {
-                        &OrderedList(_, ref lt1) if lt1 == &n_type() => (),
-                        x => panic!("Found {:?}", x),
-                    }
+        match parse_ordered_list(&vec![
+            "1. A list",
+            "     1.1. One point one",
+            "     1.2. One point two",
+        ]) {
+            Some((OrderedList(ref items, ref lt), 3)) if lt == &n_type() => match &items[0] {
+                &Paragraph(ref items) => match &items[1] {
+                    &OrderedList(_, ref lt1) if lt1 == &n_type() => (),
                     x => panic!("Found {:?}", x),
                 },
+                x => panic!("Found {:?}", x),
+            },
             x => panic!("Found {:?}", x),
         }
-
     }
 
     #[test]
@@ -166,7 +178,9 @@ mod test {
 
     #[test]
     fn no_early_matching() {
-        assert_eq!(parse_ordered_list(&vec!["test", "1. not", "2. a list"]),
-                   None);
+        assert_eq!(
+            parse_ordered_list(&vec!["test", "1. not", "2. a list"]),
+            None
+        );
     }
 }

--- a/src/parser/block/setext_header.rs
+++ b/src/parser/block/setext_header.rs
@@ -1,12 +1,12 @@
-use regex::Regex;
+use parser::span::parse_spans;
 use parser::Block;
 use parser::Block::Header;
-use parser::span::parse_spans;
+use regex::Regex;
 
 pub fn parse_setext_header(lines: &[&str]) -> Option<(Block, usize)> {
     lazy_static! {
-        static ref HORIZONTAL_RULE_1 :Regex = Regex::new(r"^===+$").unwrap();
-        static ref HORIZONTAL_RULE_2 :Regex = Regex::new(r"^---+$").unwrap();
+        static ref HORIZONTAL_RULE_1: Regex = Regex::new(r"^===+$").unwrap();
+        static ref HORIZONTAL_RULE_2: Regex = Regex::new(r"^---+$").unwrap();
     }
 
     if lines.len() > 1 {
@@ -27,16 +27,24 @@ mod test {
 
     #[test]
     fn finds_atx_header() {
-        assert_eq!(parse_setext_header(&vec!["Test", "=========="]).unwrap(),
-                   (Header(vec![Text("Test".to_owned())], 1), 2));
+        assert_eq!(
+            parse_setext_header(&vec!["Test", "=========="]).unwrap(),
+            (Header(vec![Text("Test".to_owned())], 1), 2)
+        );
 
-        assert_eq!(parse_setext_header(&vec!["Test", "----------"]).unwrap(),
-                   (Header(vec![Text("Test".to_owned())], 2), 2));
+        assert_eq!(
+            parse_setext_header(&vec!["Test", "----------"]).unwrap(),
+            (Header(vec![Text("Test".to_owned())], 2), 2)
+        );
 
-        assert_eq!(parse_setext_header(&vec!["This is a test", "==="]).unwrap(),
-                   (Header(vec![Text("This is a test".to_owned())], 1), 2));
+        assert_eq!(
+            parse_setext_header(&vec!["This is a test", "==="]).unwrap(),
+            (Header(vec![Text("This is a test".to_owned())], 1), 2)
+        );
 
-        assert_eq!(parse_setext_header(&vec!["This is a test", "---"]).unwrap(),
-                   (Header(vec![Text("This is a test".to_owned())], 2), 2));
+        assert_eq!(
+            parse_setext_header(&vec!["This is a test", "---"]).unwrap(),
+            (Header(vec![Text("This is a test".to_owned())], 2), 2)
+        );
     }
 }

--- a/src/parser/block/unordered_list.rs
+++ b/src/parser/block/unordered_list.rs
@@ -1,14 +1,15 @@
-use parser::Block;
 use parser::block::parse_blocks;
-use parser::Block::{UnorderedList, Paragraph};
+use parser::Block;
+use parser::Block::{Paragraph, UnorderedList};
 use parser::ListItem;
 use regex::Regex;
 
 pub fn parse_unordered_list(lines: &[&str]) -> Option<(Block, usize)> {
     lazy_static! {
-        static ref LIST_BEGIN :Regex = Regex::new(r"^(?P<indent> *)(-|\+|\*) (?P<content>.*)").unwrap();
-        static ref NEW_PARAGRAPH :Regex = Regex::new(r"^ +").unwrap();
-        static ref INDENTED :Regex = Regex::new(r"^ {0,4}(?P<content>.*)").unwrap();
+        static ref LIST_BEGIN: Regex =
+            Regex::new(r"^(?P<indent> *)(-|\+|\*) (?P<content>.*)").unwrap();
+        static ref NEW_PARAGRAPH: Regex = Regex::new(r"^ +").unwrap();
+        static ref INDENTED: Regex = Regex::new(r"^ {0,4}(?P<content>.*)").unwrap();
     }
 
     // if the beginning doesn't match a list don't even bother
@@ -131,7 +132,9 @@ mod test {
 
     #[test]
     fn no_early_matching() {
-        assert_eq!(parse_unordered_list(&vec!["test", "* whot", "* a list"]),
-                   None);
+        assert_eq!(
+            parse_unordered_list(&vec!["test", "* whot", "* a list"]),
+            None
+        );
     }
 }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -1,5 +1,5 @@
-mod span;
 mod block;
+mod span;
 
 #[allow(missing_docs)]
 #[derive(Debug, PartialEq, Eq, Clone)]
@@ -13,17 +13,17 @@ pub enum Block {
     Blockquote(Vec<Block>),
     CodeBlock(Option<String>, String),
     //String is the type of list: A,a,i,I or 1
-    OrderedList(Vec<ListItem>,OrderedListType),
+    OrderedList(Vec<ListItem>, OrderedListType),
     UnorderedList(Vec<ListItem>),
     Raw(String),
-    Hr
+    Hr,
 }
 
 #[allow(missing_docs)]
 #[derive(Debug, PartialEq, Clone)]
 pub enum ListItem {
     Simple(Vec<Span>),
-    Paragraph(Vec<Block>)
+    Paragraph(Vec<Block>),
 }
 
 #[allow(missing_docs)]
@@ -36,10 +36,9 @@ pub enum Span {
     Image(String, String, Option<String>),
 
     Emphasis(Vec<Span>),
-    Strong(Vec<Span>)
+    Strong(Vec<Span>),
 }
 
-pub fn parse (md : &str) -> Vec<Block> {
+pub fn parse(md: &str) -> Vec<Block> {
     block::parse_blocks(md)
 }
-

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -15,6 +15,7 @@ pub enum Block {
     //String is the type of list: A,a,i,I or 1
     OrderedList(Vec<ListItem>, OrderedListType),
     UnorderedList(Vec<ListItem>),
+    LinkReference(String, String, Option<String>),
     Raw(String),
     Hr,
 }
@@ -33,8 +34,8 @@ pub enum Span {
     Text(String),
     Code(String),
     Link(String, String, Option<String>),
+    ReferenceLink(String, String),
     Image(String, String, Option<String>),
-
     Emphasis(Vec<Span>),
     Strong(Vec<Span>),
 }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -7,7 +7,7 @@ pub enum Block {
     Header(Vec<Span>, usize),
     Paragraph(Vec<Span>),
     Blockquote(Vec<Block>),
-    CodeBlock(String),
+    CodeBlock(Option<String>, String),
     //OrderedList(Vec<ListItem>),
     UnorderedList(Vec<ListItem>),
     Raw(String),

--- a/src/parser/span/br.rs
+++ b/src/parser/span/br.rs
@@ -1,6 +1,6 @@
-use regex::Regex;
 use parser::Span;
 use parser::Span::Break;
+use regex::Regex;
 
 pub fn parse_break(text: &str) -> Option<(Span, usize)> {
     lazy_static! {
@@ -15,8 +15,8 @@ pub fn parse_break(text: &str) -> Option<(Span, usize)> {
 
 #[cfg(test)]
 mod test {
-    use parser::Span::Break;
     use super::parse_break;
+    use parser::Span::Break;
 
     #[test]
     fn finds_breaks() {

--- a/src/parser/span/code.rs
+++ b/src/parser/span/code.rs
@@ -1,11 +1,11 @@
-use regex::Regex;
 use parser::Span;
 use parser::Span::Code;
+use regex::Regex;
 
 pub fn parse_code(text: &str) -> Option<(Span, usize)> {
     lazy_static! {
-        static ref CODE_SINGLE :Regex = Regex::new(r"^`(?P<text>.+?)`").unwrap();
-        static ref CODE_DOUBLE :Regex = Regex::new(r"^``(?P<text>.+?)``").unwrap();
+        static ref CODE_SINGLE: Regex = Regex::new(r"^`(?P<text>.+?)`").unwrap();
+        static ref CODE_DOUBLE: Regex = Regex::new(r"^``(?P<text>.+?)``").unwrap();
     }
 
     if CODE_DOUBLE.is_match(text) {
@@ -22,26 +22,40 @@ pub fn parse_code(text: &str) -> Option<(Span, usize)> {
 
 #[test]
 fn finds_code() {
-    assert_eq!(parse_code("`testing things` test"),
-               Some((Code("testing things".to_owned()), 16)));
+    assert_eq!(
+        parse_code("`testing things` test"),
+        Some((Code("testing things".to_owned()), 16))
+    );
 
-    assert_eq!(parse_code("``testing things`` test"),
-               Some((Code("testing things".to_owned()), 18)));
+    assert_eq!(
+        parse_code("``testing things`` test"),
+        Some((Code("testing things".to_owned()), 18))
+    );
 
-    assert_eq!(parse_code("``testing things`` things`` test"),
-               Some((Code("testing things".to_owned()), 18)));
+    assert_eq!(
+        parse_code("``testing things`` things`` test"),
+        Some((Code("testing things".to_owned()), 18))
+    );
 
-    assert_eq!(parse_code("`w` testing things test"),
-               Some((Code("w".to_owned()), 3)));
+    assert_eq!(
+        parse_code("`w` testing things test"),
+        Some((Code("w".to_owned()), 3))
+    );
 
-    assert_eq!(parse_code("`w`` testing things test"),
-               Some((Code("w".to_owned()), 3)));
+    assert_eq!(
+        parse_code("`w`` testing things test"),
+        Some((Code("w".to_owned()), 3))
+    );
 
-    assert_eq!(parse_code("``w`` testing things test"),
-               Some((Code("w".to_owned()), 5)));
+    assert_eq!(
+        parse_code("``w`` testing things test"),
+        Some((Code("w".to_owned()), 5))
+    );
 
-    assert_eq!(parse_code("``w``` testing things test"),
-               Some((Code("w".to_owned()), 5)));
+    assert_eq!(
+        parse_code("``w``` testing things test"),
+        Some((Code("w".to_owned()), 5))
+    );
 }
 
 #[test]

--- a/src/parser/span/emphasis.rs
+++ b/src/parser/span/emphasis.rs
@@ -1,12 +1,12 @@
-use regex::Regex;
 use parser::span::parse_spans;
 use parser::Span;
 use parser::Span::Emphasis;
+use regex::Regex;
 
 pub fn parse_emphasis(text: &str) -> Option<(Span, usize)> {
     lazy_static! {
-        static ref EMPHASIS_UNDERSCORE :Regex = Regex::new(r"^_(?P<text>.+?)_").unwrap();
-        static ref EMPHASIS_STAR :Regex = Regex::new(r"^\*(?P<text>.+?)\*").unwrap();
+        static ref EMPHASIS_UNDERSCORE: Regex = Regex::new(r"^_(?P<text>.+?)_").unwrap();
+        static ref EMPHASIS_STAR: Regex = Regex::new(r"^\*(?P<text>.+?)\*").unwrap();
     }
 
     if EMPHASIS_UNDERSCORE.is_match(text) {
@@ -23,28 +23,40 @@ pub fn parse_emphasis(text: &str) -> Option<(Span, usize)> {
 
 #[cfg(test)]
 mod test {
-    use parser::Span::{Text, Emphasis};
     use super::parse_emphasis;
+    use parser::Span::{Emphasis, Text};
 
     #[test]
     fn finds_emphasis() {
-        assert_eq!(parse_emphasis("_testing things_ test"),
-                   Some((Emphasis(vec![Text("testing things".to_owned())]), 16)));
+        assert_eq!(
+            parse_emphasis("_testing things_ test"),
+            Some((Emphasis(vec![Text("testing things".to_owned())]), 16))
+        );
 
-        assert_eq!(parse_emphasis("*testing things* test"),
-                   Some((Emphasis(vec![Text("testing things".to_owned())]), 16)));
+        assert_eq!(
+            parse_emphasis("*testing things* test"),
+            Some((Emphasis(vec![Text("testing things".to_owned())]), 16))
+        );
 
-        assert_eq!(parse_emphasis("_testing things_ things_ test"),
-                   Some((Emphasis(vec![Text("testing things".to_owned())]), 16)));
+        assert_eq!(
+            parse_emphasis("_testing things_ things_ test"),
+            Some((Emphasis(vec![Text("testing things".to_owned())]), 16))
+        );
 
-        assert_eq!(parse_emphasis("_w_ things_ test"),
-                   Some((Emphasis(vec![Text("w".to_owned())]), 3)));
+        assert_eq!(
+            parse_emphasis("_w_ things_ test"),
+            Some((Emphasis(vec![Text("w".to_owned())]), 3))
+        );
 
-        assert_eq!(parse_emphasis("*w* things* test"),
-                   Some((Emphasis(vec![Text("w".to_owned())]), 3)));
+        assert_eq!(
+            parse_emphasis("*w* things* test"),
+            Some((Emphasis(vec![Text("w".to_owned())]), 3))
+        );
 
-        assert_eq!(parse_emphasis("_w__ testing things test"),
-                   Some((Emphasis(vec![Text("w".to_owned())]), 3)));
+        assert_eq!(
+            parse_emphasis("_w__ testing things test"),
+            Some((Emphasis(vec![Text("w".to_owned())]), 3))
+        );
     }
 
     #[test]

--- a/src/parser/span/image.rs
+++ b/src/parser/span/image.rs
@@ -1,17 +1,31 @@
-use regex::Regex;
 use parser::Span;
 use parser::Span::Image;
+use regex::Regex;
 
 pub fn parse_image(text: &str) -> Option<(Span, usize)> {
     lazy_static! {
-        static ref IMAGE :Regex = Regex::new("^!\\[(?P<text>.*?)\\]\\((?P<url>.*?)(?:\\s\"(?P<title>.*?)\")?\\)").unwrap();
+        static ref IMAGE: Regex =
+            Regex::new("^!\\[(?P<text>.*?)\\]\\((?P<url>.*?)(?:\\s\"(?P<title>.*?)\")?\\)")
+                .unwrap();
     }
 
     if IMAGE.is_match(text) {
         let caps = IMAGE.captures(text).unwrap();
-        let text = if let Some(mat) = caps.name("text") { mat.as_str().to_owned() } else { "".to_owned() };
-        let url = if let Some(mat) = caps.name("url") { mat.as_str().to_owned() } else { "".to_owned() };
-        let title = if let Some(mat) = caps.name("title") { Some(mat.as_str().to_owned()) } else { None };
+        let text = if let Some(mat) = caps.name("text") {
+            mat.as_str().to_owned()
+        } else {
+            "".to_owned()
+        };
+        let url = if let Some(mat) = caps.name("url") {
+            mat.as_str().to_owned()
+        } else {
+            "".to_owned()
+        };
+        let title = if let Some(mat) = caps.name("title") {
+            Some(mat.as_str().to_owned())
+        } else {
+            None
+        };
         // TODO correctly get whitespace length between url and title
         let len = text.len() + url.len() + 5 + title.clone().map_or(0, |t| t.len() + 3);
         return Some((Image(text, url, title), len));
@@ -21,28 +35,48 @@ pub fn parse_image(text: &str) -> Option<(Span, usize)> {
 
 #[test]
 fn finds_image() {
-    assert_eq!(parse_image("![an example](example.com) test"),
-               Some((Image("an example".to_owned(), "example.com".to_owned(), None),
-                     26)));
+    assert_eq!(
+        parse_image("![an example](example.com) test"),
+        Some((
+            Image("an example".to_owned(), "example.com".to_owned(), None),
+            26
+        ))
+    );
 
-    assert_eq!(parse_image("![](example.com) test"),
-               Some((Image("".to_owned(), "example.com".to_owned(), None), 16)));
+    assert_eq!(
+        parse_image("![](example.com) test"),
+        Some((Image("".to_owned(), "example.com".to_owned(), None), 16))
+    );
 
-    assert_eq!(parse_image("![an example]() test"),
-               Some((Image("an example".to_owned(), "".to_owned(), None), 15)));
+    assert_eq!(
+        parse_image("![an example]() test"),
+        Some((Image("an example".to_owned(), "".to_owned(), None), 15))
+    );
 
-    assert_eq!(parse_image("![]() test"),
-               Some((Image("".to_owned(), "".to_owned(), None), 5)));
+    assert_eq!(
+        parse_image("![]() test"),
+        Some((Image("".to_owned(), "".to_owned(), None), 5))
+    );
 
-    assert_eq!(parse_image("![an example](example.com \"Title\") test"),
-               Some((Image("an example".to_owned(),
-                           "example.com".to_owned(),
-                           Some("Title".to_owned())),
-                     34)));
+    assert_eq!(
+        parse_image("![an example](example.com \"Title\") test"),
+        Some((
+            Image(
+                "an example".to_owned(),
+                "example.com".to_owned(),
+                Some("Title".to_owned())
+            ),
+            34
+        ))
+    );
 
-    assert_eq!(parse_image("![an example](example.com) test [a link](example.com)"),
-               Some((Image("an example".to_owned(), "example.com".to_owned(), None),
-                     26)));
+    assert_eq!(
+        parse_image("![an example](example.com) test [a link](example.com)"),
+        Some((
+            Image("an example".to_owned(), "example.com".to_owned(), None),
+            26
+        ))
+    );
 }
 
 #[test]

--- a/src/parser/span/link.rs
+++ b/src/parser/span/link.rs
@@ -1,17 +1,30 @@
-use regex::Regex;
 use parser::Span;
 use parser::Span::Link;
+use regex::Regex;
 
 pub fn parse_link(text: &str) -> Option<(Span, usize)> {
     lazy_static! {
-        static ref LINK :Regex = Regex::new("^\\[(?P<text>.*?)\\]\\((?P<url>.*?)(?:\\s\"(?P<title>.*?)\")?\\)").unwrap();
+        static ref LINK: Regex =
+            Regex::new("^\\[(?P<text>.*?)\\]\\((?P<url>.*?)(?:\\s\"(?P<title>.*?)\")?\\)").unwrap();
     }
 
     if LINK.is_match(text) {
         let caps = LINK.captures(text).unwrap();
-        let text = if let Some(mat) = caps.name("text") { mat.as_str().to_owned() } else { "".to_owned() };
-        let url = if let Some(mat) = caps.name("url") { mat.as_str().to_owned() } else { "".to_owned() };
-        let title = if let Some(mat) = caps.name("title") { Some(mat.as_str().to_owned()) } else { None };
+        let text = if let Some(mat) = caps.name("text") {
+            mat.as_str().to_owned()
+        } else {
+            "".to_owned()
+        };
+        let url = if let Some(mat) = caps.name("url") {
+            mat.as_str().to_owned()
+        } else {
+            "".to_owned()
+        };
+        let title = if let Some(mat) = caps.name("title") {
+            Some(mat.as_str().to_owned())
+        } else {
+            None
+        };
         // let title = caps.name("title").map(|t| t.to_owned());
         // TODO correctly get whitespace length between url and title
         let len = text.len() + url.len() + 4 + title.clone().map_or(0, |t| t.len() + 3);
@@ -22,28 +35,48 @@ pub fn parse_link(text: &str) -> Option<(Span, usize)> {
 
 #[test]
 fn finds_link() {
-    assert_eq!(parse_link("[an example](example.com) test"),
-               Some((Link("an example".to_owned(), "example.com".to_owned(), None),
-                     25)));
+    assert_eq!(
+        parse_link("[an example](example.com) test"),
+        Some((
+            Link("an example".to_owned(), "example.com".to_owned(), None),
+            25
+        ))
+    );
 
-    assert_eq!(parse_link("[](example.com) test"),
-               Some((Link("".to_owned(), "example.com".to_owned(), None), 15)));
+    assert_eq!(
+        parse_link("[](example.com) test"),
+        Some((Link("".to_owned(), "example.com".to_owned(), None), 15))
+    );
 
-    assert_eq!(parse_link("[an example]() test"),
-               Some((Link("an example".to_owned(), "".to_owned(), None), 14)));
+    assert_eq!(
+        parse_link("[an example]() test"),
+        Some((Link("an example".to_owned(), "".to_owned(), None), 14))
+    );
 
-    assert_eq!(parse_link("[]() test"),
-               Some((Link("".to_owned(), "".to_owned(), None), 4)));
+    assert_eq!(
+        parse_link("[]() test"),
+        Some((Link("".to_owned(), "".to_owned(), None), 4))
+    );
 
-    assert_eq!(parse_link("[an example](example.com \"Title\") test"),
-               Some((Link("an example".to_owned(),
-                          "example.com".to_owned(),
-                          Some("Title".to_owned())),
-                     33)));
+    assert_eq!(
+        parse_link("[an example](example.com \"Title\") test"),
+        Some((
+            Link(
+                "an example".to_owned(),
+                "example.com".to_owned(),
+                Some("Title".to_owned())
+            ),
+            33
+        ))
+    );
 
-    assert_eq!(parse_link("[an example](example.com) test [a link](example.com)"),
-               Some((Link("an example".to_owned(), "example.com".to_owned(), None),
-                     25)));
+    assert_eq!(
+        parse_link("[an example](example.com) test [a link](example.com)"),
+        Some((
+            Link("an example".to_owned(), "example.com".to_owned(), None),
+            25
+        ))
+    );
 }
 
 #[test]

--- a/src/parser/span/mod.rs
+++ b/src/parser/span/mod.rs
@@ -6,12 +6,14 @@ mod code;
 mod emphasis;
 mod image;
 mod link;
+mod reference_link;
 mod strong;
 use self::br::parse_break;
 use self::code::parse_code;
 use self::emphasis::parse_emphasis;
 use self::image::parse_image;
 use self::link::parse_link;
+use self::reference_link::parse_reference_link;
 use self::strong::parse_strong;
 
 pub fn parse_spans(text: &str) -> Vec<Span> {
@@ -67,13 +69,14 @@ fn parse_span(text: &str) -> Option<(Span, usize)> {
     => parse_break
     => parse_image
     => parse_link
+    => parse_reference_link
     )
 }
 
 #[cfg(test)]
 mod test {
     use parser::span::parse_spans;
-    use parser::Span::{Break, Code, Emphasis, Image, Link, Strong, Text};
+    use parser::Span::{Break, Code, Emphasis, Image, Link, ReferenceLink, Strong, Text};
     use std::str;
 
     #[test]
@@ -165,6 +168,18 @@ mod test {
     }
 
     #[test]
+    fn finds_reference_link() {
+        assert_eq!(
+            parse_spans("this is [an example][ref] test"),
+            vec![
+                Text("this is ".to_owned()),
+                ReferenceLink("an example".to_owned(), "ref".to_owned()),
+                Text(" test".to_owned())
+            ]
+        );
+    }
+
+    #[test]
     fn finds_image() {
         assert_eq!(
             parse_spans("this is ![an example](example.com) test"),
@@ -179,7 +194,7 @@ mod test {
     #[test]
     fn finds_everything() {
         assert_eq!(
-            parse_spans("some text ![an image](image.com) _emphasis_ __strong__ `teh codez` [a link](example.com)  "),
+            parse_spans("some text ![an image](image.com) _emphasis_ __strong__ `teh codez` [a link](example.com) [ref link][ref]  "),
             vec![
             Text("some text ".to_owned()),
             Image("an image".to_owned(), "image.com".to_owned(), None),
@@ -191,6 +206,8 @@ mod test {
             Code("teh codez".to_owned()),
             Text(" ".to_owned()),
             Link("a link".to_owned(), "example.com".to_owned(), None),
+            Text(" ".to_owned()),
+            ReferenceLink("ref link".to_owned(), "ref".to_owned()),
             Break
             ]
             );

--- a/src/parser/span/mod.rs
+++ b/src/parser/span/mod.rs
@@ -4,24 +4,24 @@ use parser::Span::Text;
 mod br;
 mod code;
 mod emphasis;
-mod strong;
-mod link;
 mod image;
+mod link;
+mod strong;
 use self::br::parse_break;
 use self::code::parse_code;
 use self::emphasis::parse_emphasis;
-use self::strong::parse_strong;
-use self::link::parse_link;
 use self::image::parse_image;
+use self::link::parse_link;
+use self::strong::parse_strong;
 
-pub fn parse_spans(text: &str) -> Vec<Span>{
+pub fn parse_spans(text: &str) -> Vec<Span> {
     let mut tokens = vec![];
     let mut t = String::new();
     let mut i = 0;
     while i < text.len() {
-        match parse_span(&text[i .. text.len()]){
+        match parse_span(&text[i..text.len()]) {
             Some((span, consumed_chars)) => {
-                if !t.is_empty(){
+                if !t.is_empty() {
                     // if this text is on the very left
                     // trim the left whitespace
                     if tokens.is_empty() {
@@ -44,7 +44,7 @@ pub fn parse_spans(text: &str) -> Vec<Span>{
             }
         }
     }
-    if !t.is_empty(){
+    if !t.is_empty() {
         // if this text is on the very left
         // trim the left whitespace
         if tokens.is_empty() {
@@ -58,66 +58,122 @@ pub fn parse_spans(text: &str) -> Vec<Span>{
     tokens
 }
 
-fn parse_span(text: &str) -> Option<(Span, usize)>{
+fn parse_span(text: &str) -> Option<(Span, usize)> {
     pipe_opt!(
-        text
-        => parse_code
-        => parse_strong
-        => parse_emphasis
-        => parse_break
-        => parse_image
-        => parse_link
-        )
+    text
+    => parse_code
+    => parse_strong
+    => parse_emphasis
+    => parse_break
+    => parse_image
+    => parse_link
+    )
 }
 
 #[cfg(test)]
 mod test {
-    use parser::Span::{Text, Break, Code, Emphasis, Strong, Link, Image};
     use parser::span::parse_spans;
+    use parser::Span::{Break, Code, Emphasis, Image, Link, Strong, Text};
     use std::str;
 
     #[test]
     fn converts_into_text() {
-        assert_eq!(parse_spans("this is a test"), vec![Text("this is a test".to_owned())]);
+        assert_eq!(
+            parse_spans("this is a test"),
+            vec![Text("this is a test".to_owned())]
+        );
     }
 
     #[test]
     fn finds_breaks() {
-        assert_eq!(parse_spans("this is a test  "), vec![Text("this is a test".to_owned()), Break]);
+        assert_eq!(
+            parse_spans("this is a test  "),
+            vec![Text("this is a test".to_owned()), Break]
+        );
     }
 
     #[test]
     fn finds_code() {
-        assert_eq!(parse_spans("this `is a` test"), vec![Text("this ".to_owned()), Code("is a".to_owned()), Text(" test".to_owned())]);
-        assert_eq!(parse_spans("this ``is a`` test"), vec![Text("this ".to_owned()), Code("is a".to_owned()), Text(" test".to_owned())]);
+        assert_eq!(
+            parse_spans("this `is a` test"),
+            vec![
+                Text("this ".to_owned()),
+                Code("is a".to_owned()),
+                Text(" test".to_owned())
+            ]
+        );
+        assert_eq!(
+            parse_spans("this ``is a`` test"),
+            vec![
+                Text("this ".to_owned()),
+                Code("is a".to_owned()),
+                Text(" test".to_owned())
+            ]
+        );
     }
 
     #[test]
     fn finds_emphasis() {
-        assert_eq!(parse_spans("this _is a_ test"), vec![Text("this ".to_owned()), Emphasis(vec![Text("is a".to_owned())]), Text(" test".to_owned())]);
-        assert_eq!(parse_spans("this *is a* test"), vec![Text("this ".to_owned()), Emphasis(vec![Text("is a".to_owned())]), Text(" test".to_owned())]);
+        assert_eq!(
+            parse_spans("this _is a_ test"),
+            vec![
+                Text("this ".to_owned()),
+                Emphasis(vec![Text("is a".to_owned())]),
+                Text(" test".to_owned())
+            ]
+        );
+        assert_eq!(
+            parse_spans("this *is a* test"),
+            vec![
+                Text("this ".to_owned()),
+                Emphasis(vec![Text("is a".to_owned())]),
+                Text(" test".to_owned())
+            ]
+        );
     }
 
     #[test]
     fn finds_strong() {
-        assert_eq!(parse_spans("this __is a__ test"), vec![Text("this ".to_owned()), Strong(vec![Text("is a".to_owned())]), Text(" test".to_owned())]);
-        assert_eq!(parse_spans("this **is a** test"), vec![Text("this ".to_owned()), Strong(vec![Text("is a".to_owned())]), Text(" test".to_owned())]);
+        assert_eq!(
+            parse_spans("this __is a__ test"),
+            vec![
+                Text("this ".to_owned()),
+                Strong(vec![Text("is a".to_owned())]),
+                Text(" test".to_owned())
+            ]
+        );
+        assert_eq!(
+            parse_spans("this **is a** test"),
+            vec![
+                Text("this ".to_owned()),
+                Strong(vec![Text("is a".to_owned())]),
+                Text(" test".to_owned())
+            ]
+        );
     }
 
     #[test]
     fn finds_link() {
         assert_eq!(
             parse_spans("this is [an example](example.com) test"),
-            vec![Text("this is ".to_owned()), Link("an example".to_owned(), "example.com".to_owned(), None), Text(" test".to_owned())]
-            );
+            vec![
+                Text("this is ".to_owned()),
+                Link("an example".to_owned(), "example.com".to_owned(), None),
+                Text(" test".to_owned())
+            ]
+        );
     }
 
     #[test]
     fn finds_image() {
         assert_eq!(
             parse_spans("this is ![an example](example.com) test"),
-            vec![Text("this is ".to_owned()), Image("an example".to_owned(), "example.com".to_owned(), None), Text(" test".to_owned())]
-            );
+            vec![
+                Text("this is ".to_owned()),
+                Image("an example".to_owned(), "example.com".to_owned(), None),
+                Text(" test".to_owned())
+            ]
+        );
     }
 
     #[test]
@@ -146,4 +202,3 @@ mod test {
         let _ = parse_spans(&test_phrase);
     }
 }
-

--- a/src/parser/span/reference_link.rs
+++ b/src/parser/span/reference_link.rs
@@ -1,0 +1,76 @@
+use parser::Span;
+use parser::Span::ReferenceLink;
+use regex::Regex;
+
+pub fn parse_reference_link(text: &str) -> Option<(Span, usize)> {
+    lazy_static! {
+        static ref LINK: Regex =
+            Regex::new("^\\[(?P<text>.*?)\\]\\[(?P<url>.*?)\\]").unwrap();
+    }
+
+    if LINK.is_match(text) {
+        let caps = LINK.captures(text).unwrap();
+        let text = if let Some(mat) = caps.name("text") {
+            mat.as_str().to_owned()
+        } else {
+            "".to_owned()
+        };
+        let url = if let Some(mat) = caps.name("url") {
+            mat.as_str().to_owned()
+        } else {
+            "".to_owned()
+        };
+
+        let len = text.len() + url.len() + 4;
+        return Some((ReferenceLink(text, url), len));
+    }
+    None
+}
+
+#[test]
+fn finds_link() {
+    assert_eq!(
+        parse_reference_link("[an example][ref] test"),
+        Some((
+            ReferenceLink("an example".to_owned(), "ref".to_owned()),
+            17
+        ))
+    );
+
+    assert_eq!(
+        parse_reference_link("[][ref] test"),
+        Some((ReferenceLink("".to_owned(), "ref".to_owned()), 7))
+    );
+
+    assert_eq!(
+        parse_reference_link("[an example][] test"),
+        Some((ReferenceLink("an example".to_owned(), "".to_owned()), 14))
+    );
+
+    assert_eq!(
+        parse_reference_link("[][] test"),
+        Some((ReferenceLink("".to_owned(), "".to_owned()), 4))
+    );
+
+
+    assert_eq!(
+        parse_reference_link("[an example][example] test [a link](example.com)"),
+        Some((
+            ReferenceLink("an example".to_owned(), "example".to_owned()),
+            21
+        ))
+    );
+}
+
+#[test]
+fn no_false_positives() {
+    assert_eq!(parse_reference_link("[[]] testing things test"), None);
+    assert_eq!(parse_reference_link("[[]] testing things test"), None);
+    assert_eq!(parse_reference_link("[]: testing things test"), None);
+    assert_eq!(parse_reference_link("][[] testing things test"), None);
+}
+
+#[test]
+fn no_early_matching() {
+    assert_eq!(parse_reference_link("were [an example][example] test"), None);
+}

--- a/src/parser/span/reference_link.rs
+++ b/src/parser/span/reference_link.rs
@@ -4,8 +4,7 @@ use regex::Regex;
 
 pub fn parse_reference_link(text: &str) -> Option<(Span, usize)> {
     lazy_static! {
-        static ref LINK: Regex =
-            Regex::new("^\\[(?P<text>.*?)\\]\\[(?P<url>.*?)\\]").unwrap();
+        static ref LINK: Regex = Regex::new("^\\[(?P<text>.*?)\\]\\[(?P<url>.*?)\\]").unwrap();
     }
 
     if LINK.is_match(text) {
@@ -31,10 +30,7 @@ pub fn parse_reference_link(text: &str) -> Option<(Span, usize)> {
 fn finds_link() {
     assert_eq!(
         parse_reference_link("[an example][ref] test"),
-        Some((
-            ReferenceLink("an example".to_owned(), "ref".to_owned()),
-            17
-        ))
+        Some((ReferenceLink("an example".to_owned(), "ref".to_owned()), 17))
     );
 
     assert_eq!(
@@ -51,7 +47,6 @@ fn finds_link() {
         parse_reference_link("[][] test"),
         Some((ReferenceLink("".to_owned(), "".to_owned()), 4))
     );
-
 
     assert_eq!(
         parse_reference_link("[an example][example] test [a link](example.com)"),
@@ -72,5 +67,8 @@ fn no_false_positives() {
 
 #[test]
 fn no_early_matching() {
-    assert_eq!(parse_reference_link("were [an example][example] test"), None);
+    assert_eq!(
+        parse_reference_link("were [an example][example] test"),
+        None
+    );
 }

--- a/src/parser/span/strong.rs
+++ b/src/parser/span/strong.rs
@@ -1,12 +1,12 @@
-use regex::Regex;
 use parser::span::parse_spans;
 use parser::Span;
 use parser::Span::Strong;
+use regex::Regex;
 
 pub fn parse_strong(text: &str) -> Option<(Span, usize)> {
     lazy_static! {
-        static ref STRONG_UNDERSCORE :Regex = Regex::new(r"^__(?P<text>.+?)__").unwrap();
-        static ref STRONG_STAR :Regex = Regex::new(r"^\*\*(?P<text>.+?)\*\*").unwrap();
+        static ref STRONG_UNDERSCORE: Regex = Regex::new(r"^__(?P<text>.+?)__").unwrap();
+        static ref STRONG_STAR: Regex = Regex::new(r"^\*\*(?P<text>.+?)\*\*").unwrap();
     }
 
     if STRONG_UNDERSCORE.is_match(text) {
@@ -23,28 +23,40 @@ pub fn parse_strong(text: &str) -> Option<(Span, usize)> {
 
 #[cfg(test)]
 mod test {
-    use parser::Span::{Text, Strong};
     use super::parse_strong;
+    use parser::Span::{Strong, Text};
 
     #[test]
     fn finds_strong() {
-        assert_eq!(parse_strong("__testing things__ test"),
-                   Some((Strong(vec![Text("testing things".to_owned())]), 18)));
+        assert_eq!(
+            parse_strong("__testing things__ test"),
+            Some((Strong(vec![Text("testing things".to_owned())]), 18))
+        );
 
-        assert_eq!(parse_strong("**testing things** test"),
-                   Some((Strong(vec![Text("testing things".to_owned())]), 18)));
+        assert_eq!(
+            parse_strong("**testing things** test"),
+            Some((Strong(vec![Text("testing things".to_owned())]), 18))
+        );
 
-        assert_eq!(parse_strong("__testing things__ things__ test"),
-                   Some((Strong(vec![Text("testing things".to_owned())]), 18)));
+        assert_eq!(
+            parse_strong("__testing things__ things__ test"),
+            Some((Strong(vec![Text("testing things".to_owned())]), 18))
+        );
 
-        assert_eq!(parse_strong("__w__ things_ test"),
-                   Some((Strong(vec![Text("w".to_owned())]), 5)));
+        assert_eq!(
+            parse_strong("__w__ things_ test"),
+            Some((Strong(vec![Text("w".to_owned())]), 5))
+        );
 
-        assert_eq!(parse_strong("**w** things** test"),
-                   Some((Strong(vec![Text("w".to_owned())]), 5)));
+        assert_eq!(
+            parse_strong("**w** things** test"),
+            Some((Strong(vec![Text("w".to_owned())]), 5))
+        );
 
-        assert_eq!(parse_strong("__w___ testing things test"),
-                   Some((Strong(vec![Text("w".to_owned())]), 5)));
+        assert_eq!(
+            parse_strong("__w___ testing things test"),
+            Some((Strong(vec![Text("w".to_owned())]), 5))
+        );
     }
 
     #[test]

--- a/tests/fixtures/markdown-rs/ref_link.html
+++ b/tests/fixtures/markdown-rs/ref_link.html
@@ -1,0 +1,1 @@
+<p>Do references work? <a href='https://duck.com'>DuckDuckGo</a></p>

--- a/tests/fixtures/markdown-rs/ref_link.md
+++ b/tests/fixtures/markdown-rs/ref_link.md
@@ -1,0 +1,3 @@
+Do references work? [DuckDuckGo][duck]
+
+[duck]: https://duck.com

--- a/tests/fixtures/markdown-rs/ref_link_no_ref.html
+++ b/tests/fixtures/markdown-rs/ref_link_no_ref.html
@@ -1,0 +1,1 @@
+<p>Because there isn&#8217;t a reference, [this link][null] shouldn&#8217;t transform.</p>

--- a/tests/fixtures/markdown-rs/ref_link_no_ref.md
+++ b/tests/fixtures/markdown-rs/ref_link_no_ref.md
@@ -1,0 +1,1 @@
+Because there isn't a reference, [this link][null] shouldn't transform.

--- a/tests/fixtures/markdown-rs/ref_links.html
+++ b/tests/fixtures/markdown-rs/ref_links.html
@@ -1,0 +1,1 @@
+<p><a href='https://two.com'>Two</a> <a href='https://reflinks.com'>Reflinks</a></p>

--- a/tests/fixtures/markdown-rs/ref_links.md
+++ b/tests/fixtures/markdown-rs/ref_links.md
@@ -1,0 +1,4 @@
+[Two][two] [Reflinks][reflinks]
+
+[two]: https://two.com
+[reflinks]: https://reflinks.com

--- a/tests/fixtures/markdown-rs/ref_links_staggered.html
+++ b/tests/fixtures/markdown-rs/ref_links_staggered.html
@@ -1,0 +1,3 @@
+<p>First <a href='https://one.com'>One</a></p>
+
+<p>Second <a href='https://two.com'>Two</a></p>

--- a/tests/fixtures/markdown-rs/ref_links_staggered.md
+++ b/tests/fixtures/markdown-rs/ref_links_staggered.md
@@ -1,0 +1,7 @@
+First [One][one]
+
+[one]: https://one.com
+
+Second [Two][two]
+
+[two]: https://two.com

--- a/tests/fixtures/mod.rs
+++ b/tests/fixtures/mod.rs
@@ -4,9 +4,7 @@ use std::fs::File;
 use std::io::Read;
 use std::path::Path;
 
-fn compare(name: &str) {
-    let html = format!("tests/fixtures/docs-maruku-unittest/{}.html", name);
-    let text = format!("tests/fixtures/docs-maruku-unittest/{}.text", name);
+fn compare_fn(html: String, text: String) {
     let mut comp = String::new();
     File::open(Path::new(&html))
         .unwrap()
@@ -17,8 +15,24 @@ fn compare(name: &str) {
     let mut tokens = String::new();
     File::open(md).unwrap().read_to_string(&mut tokens).unwrap();
     println!("{:?}", markdown::tokenize(&tokens));
+    let generated = markdown::file_to_html(md).unwrap();
+    println!("{}", generated);
 
-    difference::assert_diff(&comp, &markdown::file_to_html(md).unwrap(), " ", 0);
+    difference::assert_diff(&comp, &generated, " ", 0);
+}
+
+fn compare(name: &str) {
+    compare_fn(
+        format!("tests/fixtures/docs-maruku-unittest/{}.html", name),
+        format!("tests/fixtures/docs-maruku-unittest/{}.text", name),
+    )
+}
+
+fn us_compare(name: &str) {
+    compare_fn(
+        format!("tests/fixtures/markdown-rs/{}.html", name),
+        format!("tests/fixtures/markdown-rs/{}.md", name),
+    )
 }
 
 fn roundtrip(name: &str) {
@@ -231,4 +245,19 @@ pub fn test() {
 #[test]
 pub fn wrapping() {
     compare("wrapping")
+}
+
+#[test]
+pub fn ref_link() {
+    us_compare("ref_link")
+}
+
+#[test]
+pub fn ref_links() {
+    us_compare("ref_links")
+}
+
+#[test]
+pub fn ref_lnks_staggered() {
+    us_compare("ref_links_staggered")
 }

--- a/tests/fixtures/mod.rs
+++ b/tests/fixtures/mod.rs
@@ -253,6 +253,11 @@ pub fn ref_link() {
 }
 
 #[test]
+pub fn ref_link_no_ref() {
+    us_compare("ref_link_no_ref")
+}
+
+#[test]
 pub fn ref_links() {
     us_compare("ref_links")
 }

--- a/tests/fixtures/mod.rs
+++ b/tests/fixtures/mod.rs
@@ -1,14 +1,17 @@
-use std::path::Path;
+use difference;
+use markdown;
 use std::fs::File;
 use std::io::Read;
-use markdown;
-use difference;
+use std::path::Path;
 
 fn compare(name: &str) {
     let html = format!("tests/fixtures/docs-maruku-unittest/{}.html", name);
     let text = format!("tests/fixtures/docs-maruku-unittest/{}.text", name);
     let mut comp = String::new();
-    File::open(Path::new(&html)).unwrap().read_to_string(&mut comp).unwrap();
+    File::open(Path::new(&html))
+        .unwrap()
+        .read_to_string(&mut comp)
+        .unwrap();
     let md = Path::new(&text);
 
     let mut tokens = String::new();
@@ -22,18 +25,21 @@ fn roundtrip(name: &str) {
     let html = format!("tests/fixtures/docs-maruku-unittest/{}.html", name);
     let text = format!("tests/fixtures/docs-maruku-unittest/{}.text", name);
     let mut comp = String::new();
-    File::open(Path::new(&html)).unwrap().read_to_string(&mut comp).unwrap();
+    File::open(Path::new(&html))
+        .unwrap()
+        .read_to_string(&mut comp)
+        .unwrap();
     let md = Path::new(&text);
 
     let mut tokens = String::new();
     File::open(md).unwrap().read_to_string(&mut tokens).unwrap();
-    
+
     let v = markdown::tokenize(&tokens);
     println!("{:?}", v);
     let out = markdown::generate_markdown(v);
-    
+
     println!("BEGIN\n{}\nEND", out);
-    
+
     difference::assert_diff(&comp, &markdown::to_html(&out), " ", 0);
 }
 
@@ -47,24 +53,20 @@ pub fn rt_blank() {
     roundtrip("blank")
 }
 
-
 #[test]
 pub fn rt_blanks_in_code() {
     roundtrip("blanks_in_code")
 }
-
 
 #[test]
 pub fn rt_code() {
     roundtrip("code")
 }
 
-
 #[test]
 pub fn rt_code2() {
     roundtrip("code2")
 }
-
 
 #[test]
 pub fn rt_code3() {
@@ -83,7 +85,7 @@ pub fn rt_headers() {
 
 //#[test]
 //pub fn rt_entities() {
-    //roundtrip("entities")
+//roundtrip("entities")
 //}
 
 #[test]
@@ -136,13 +138,10 @@ pub fn rt_wrapping() {
     roundtrip("wrapping")
 }
 
-
-
 #[test]
 pub fn alt() {
     compare("alt")
 }
-
 
 #[test]
 pub fn blank() {
@@ -181,7 +180,7 @@ pub fn headers() {
 
 //#[test]
 //pub fn entities() {
-    //compare("entities")
+//compare("entities")
 //}
 
 #[test]
@@ -233,4 +232,3 @@ pub fn test() {
 pub fn wrapping() {
     compare("wrapping")
 }
-

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -1,4 +1,4 @@
-extern crate markdown;
 extern crate difference;
+extern crate markdown;
 
 mod fixtures;


### PR DESCRIPTION
Allows GitHub flavored markdown code fences (closes #24?). If a language is provided, there will be a `class` attribute on the `<code>` tag. For example, if the language was rust, it would look like:
```html
<pre><code class="language-rust">
fn main() {
    //Rusty code
}
</pre></continue>
```

I tested to make sure it didn't mess with the formatting of code (preserves newlines, tabs, spaces).