### PR TITLE
Allow code blocks with three backticks

### DIFF
--- a/src/html.rs
+++ b/src/html.rs
@@ -99,11 +99,11 @@ fn format_unordered_list(elements: &[ListItem]) -> String {
     format!("<ul>{}</ul>\n\n", ret)
 }
 
-fn format_codeblock(language: &Option<String>,elements: &str) -> String {
-    if language.is_none() {
+fn format_codeblock(lang: &Option<String>,elements: &str) -> String {
+    if lang.is_none() || (lang.is_some() && lang.as_ref().unwrap().is_empty()) {
         format!("<pre><code>{}</code></pre>\n\n", &escape(elements))
     } else {
-        format!("<pre><code class=\"language-{}\">{}</code></pre>\n\n", &escape(language.as_ref().unwrap()), &escape(elements))
+        format!("<pre><code class=\"language-{}\">{}</code></pre>\n\n", &escape(lang.as_ref().unwrap()), &escape(elements))
     }
 }
 

--- a/src/html.rs
+++ b/src/html.rs
@@ -33,7 +33,7 @@ pub fn to_html(blocks: &[Block]) -> String {
             Header(ref elements, level) => format_header(elements, level),
             Paragraph(ref elements) => format_paragraph(elements),
             Blockquote(ref elements) => format_blockquote(elements),
-            CodeBlock(ref elements) => format_codeblock(elements),
+            CodeBlock(ref lang, ref elements) => format_codeblock(lang, elements),
             UnorderedList(ref elements) => format_unordered_list(elements),
             Raw(ref elements) => elements.to_owned(),
             Hr => format!("<hr>"),
@@ -99,8 +99,12 @@ fn format_unordered_list(elements: &[ListItem]) -> String {
     format!("<ul>{}</ul>\n\n", ret)
 }
 
-fn format_codeblock(elements: &str) -> String {
-    format!("<pre><code>{}</code></pre>\n\n", &escape(elements))
+fn format_codeblock(language: &Option<String>,elements: &str) -> String {
+    if language.is_none() {
+        format!("<pre><code>{}</code></pre>\n\n", &escape(elements))
+    } else {
+        format!("<pre><code class=\"language-{}\">{}</code></pre>\n\n", &escape(language.as_ref().unwrap()), &escape(elements))
+    }
 }
 
 fn format_blockquote(elements: &[Block]) -> String {

--- a/src/markdown_generator/mod.rs
+++ b/src/markdown_generator/mod.rs
@@ -19,7 +19,13 @@ fn gen_block(b : Block) -> String {
                 ),
         Paragraph(s) => generate_from_spans(s),
         Blockquote(bb) => generate(bb).lines().map(|x|format!("> {}", x)).j("\n"),
-        CodeBlock(x) => x.lines().map(|x|format!("    {}",x)).j("\n"),
+        CodeBlock(lang, x) => {
+            if lang.is_none() {
+                x.lines().map(|x|format!("    {}",x)).j("\n")
+            } else {
+                format!("```{}\n{}```", lang.unwrap(), x)
+            }
+        },
         //OrderedList(Vec<ListItem>),
         UnorderedList(x) => generate_from_li(x),
         Raw(x) => x,

--- a/src/parser/block/code_block.rs
+++ b/src/parser/block/code_block.rs
@@ -1,40 +1,65 @@
-use regex::Regex;
 use parser::Block;
 use parser::Block::CodeBlock;
+use regex::Regex;
 
 pub fn parse_code_block(lines: &[&str]) -> Option<(Block, usize)> {
     lazy_static! {
-        static ref CODE_BLOCK_SPACES :Regex = Regex::new(r"^ {4}").unwrap();
-        static ref CODE_BLOCK_TABS :Regex = Regex::new(r"^\t").unwrap();
+        static ref CODE_BLOCK_SPACES: Regex = Regex::new(r"^ {4}").unwrap();
+        static ref CODE_BLOCK_TABS: Regex = Regex::new(r"^\t").unwrap();
+        static ref CODE_BLOCK_BACKTICKS: Regex = Regex::new(r"```").unwrap();
     }
 
     let mut content = String::new();
-    let mut i = 0;
+    let mut lang: Option<String> = None;
+    let mut line_number = 0;
+    let mut backtick_opened = false;
+    let mut backtick_closed = false;
+
     for line in lines {
-        if CODE_BLOCK_SPACES.is_match(line) {
-            if i > 0 && !content.is_empty() {
+        if !backtick_opened && CODE_BLOCK_SPACES.is_match(line) {
+            if line_number > 0 && !content.is_empty() {
                 content.push('\n');
             }
             // remove top-level spaces
             content.push_str(&line[4..line.len()]);
-            i += 1;
-        } else if CODE_BLOCK_TABS.is_match(line) {
-            if i > 0 && !content.is_empty() {
+            line_number += 1;
+        } else if !backtick_opened && CODE_BLOCK_TABS.is_match(line) {
+            if line_number > 0 && !content.is_empty() {
                 content.push('\n');
             }
 
-            if !(i == 0 && line.trim().is_empty()) {
+            if !(line_number == 0 && line.trim().is_empty()) {
                 // remove top-level spaces
                 content.push_str(&line[1..line.len()]);
             }
-            i += 1;
+            line_number += 1;
+        } else if CODE_BLOCK_BACKTICKS.is_match(line) {
+            line_number += 1;
+
+            if !backtick_opened && !(line_number == 0 && line.get(3..).is_some()) {
+                lang = Some(String::from(line.get(3..).unwrap()));
+                backtick_opened = true;
+            } else if backtick_opened {
+                backtick_closed = true;
+                break;
+            }
+        } else if backtick_opened {
+            content.push_str(line);
+            content.push('\n');
+
+            line_number += 1;
         } else {
             break;
         }
     }
-    if i > 0 {
-        return Some((CodeBlock(content.trim_matches('\n').to_owned()), i));
+
+    if line_number > 0 && ((backtick_opened && backtick_closed) || !backtick_opened) {
+        return Some((
+            CodeBlock(lang, content.trim_matches('\n').to_owned()),
+            line_number,
+        ));
     }
+
     None
 }
 
@@ -45,17 +70,28 @@ mod test {
 
     #[test]
     fn finds_code_block() {
-        assert_eq!(parse_code_block(&vec!["    Test"]).unwrap(),
-                   ((CodeBlock("Test".to_owned()), 1)));
+        assert_eq!(
+            parse_code_block(&vec!["    Test"]).unwrap(),
+            ((CodeBlock(None, "Test".to_owned()), 1))
+        );
 
-        assert_eq!(parse_code_block(&vec!["    Test", "    this"]).unwrap(),
-                   ((CodeBlock("Test\nthis".to_owned()), 2)));
+        assert_eq!(
+            parse_code_block(&vec!["    Test", "    this"]).unwrap(),
+            ((CodeBlock(None, "Test\nthis".to_owned()), 2))
+        );
+
+        assert_eq!(
+            parse_code_block(&vec!["```testlang", "Test", "this", "```"]).unwrap(),
+            ((CodeBlock(Some(String::from("testlang")), "Test\nthis".to_owned()), 4))
+        );
     }
 
     #[test]
     fn knows_when_to_stop() {
-        assert_eq!(parse_code_block(&vec!["    Test", "    this", "stuff", "    now"]).unwrap(),
-                   ((CodeBlock("Test\nthis".to_owned()), 2)));
+        assert_eq!(
+            parse_code_block(&vec!["    Test", "    this", "stuff", "    now"]).unwrap(),
+            ((CodeBlock(None, "Test\nthis".to_owned()), 2))
+        );
     }
 
     #[test]
@@ -65,7 +101,9 @@ mod test {
 
     #[test]
     fn no_early_matching() {
-        assert_eq!(parse_code_block(&vec!["Test", "    this", "stuff", "    now"]),
-                   None);
+        assert_eq!(
+            parse_code_block(&vec!["Test", "    this", "stuff", "    now"]),
+            None
+        );
     }
 }

--- a/src/parser/block/mod.rs
+++ b/src/parser/block/mod.rs
@@ -119,8 +119,13 @@ mod test {
     fn finds_code_block() {
         assert_eq!(
             parse_blocks("    this is code\n    and this as well"),
-            vec![CodeBlock("this is code\nand this as well".to_owned())]
-            );
+            vec![CodeBlock(None, "this is code\nand this as well".to_owned())]
+        );
+
+        assert_eq!(
+            parse_blocks("```\nthis is code\nand this as well\n```"),
+            vec![CodeBlock(Some(String::new()), "this is code\nand this as well".to_owned())]
+        );
     }
 
     #[test]

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -7,7 +7,7 @@ pub enum Block {
     Header(Vec<Span>, usize),
     Paragraph(Vec<Span>),
     Blockquote(Vec<Block>),
-    CodeBlock(String),
+    CodeBlock(Option<String>, String),
     //OrderedList(Vec<ListItem>),
     UnorderedList(Vec<ListItem>),
     Raw(String),


### PR DESCRIPTION
This is the same as #30, but setup to merge from a branch with only these commits.

Allows GitHub flavored markdown code fences (closes #24?). If a language is provided, there will be a `class` attribute on the `<code>` tag. For example, if the language was rust, it would look like:
```html
<pre><code class="language-rust">
fn main() {
    //Rusty code
}
</pre></continue>
```

I tested to make sure it didn't mess with the formatting of code (preserves newlines, tabs, spaces).