### PR TITLE
Support for inline HTML blocks

### DIFF
--- a/src/html.rs
+++ b/src/html.rs
@@ -1,6 +1,7 @@
 use parser::Block;
 use parser::Block::{
-    Blockquote, CodeBlock, Header, Hr, LinkReference, OrderedList, Paragraph, Raw, UnorderedList,
+    Blockquote, CodeBlock, Header, Hr, HtmlBlock, LinkReference, OrderedList, Paragraph, Raw,
+    UnorderedList,
 };
 use parser::Span::{Break, Code, Emphasis, Image, Link, Literal, RefLink, Strong, Text};
 use parser::{ListItem, OrderedListType, Span};
@@ -53,6 +54,7 @@ pub fn to_html(blocks: &[Block]) -> String {
             Paragraph(ref elements) => format_paragraph(elements, &link_references),
             Blockquote(ref elements) => format_blockquote(elements),
             CodeBlock(ref lang, ref elements) => format_codeblock(lang, elements),
+            HtmlBlock(ref content) => format_htmlblock(content),
             UnorderedList(ref elements) => format_unordered_list(elements, &link_references),
             OrderedList(ref elements, ref num_type) => {
                 format_ordered_list(elements, num_type, &link_references)
@@ -220,6 +222,10 @@ fn format_codeblock(lang: &Option<String>, elements: &str) -> String {
             &escape(elements, false)
         )
     }
+}
+
+fn format_htmlblock(content: &String) -> String {
+    format!("{}\n", content)
 }
 
 fn format_blockquote(elements: &[Block]) -> String {

--- a/src/markdown_generator/mod.rs
+++ b/src/markdown_generator/mod.rs
@@ -33,6 +33,7 @@ fn gen_block(b: Block) -> String {
                 format!("```{}\n{}```", lang.unwrap(), x)
             }
         }
+        HtmlBlock(_x) => unimplemented!("Generate HTML block"),
         // [TODO]: Ordered list generation - 2017-12-10 10:12pm
         OrderedList(_x, _num_type) => unimplemented!("Generate ordered list"),
         UnorderedList(x) => generate_from_li(x),

--- a/src/parser/block/html_block.rs
+++ b/src/parser/block/html_block.rs
@@ -81,7 +81,7 @@ pub fn parse_html_block(lines: &[&str]) -> Option<(Block, usize)> {
         while let Some((tag, h, t)) = find_tag(&line[offset..]) {
             let idx = offset + h;
             offset += t;
-            if open_tag.len() > 0 {
+            if !open_tag.is_empty() {
                 if tag == open_tag {
                     // Deal with matching nested start-tags.
                     nest_count += 1;
@@ -120,8 +120,10 @@ pub fn parse_html_block(lines: &[&str]) -> Option<(Block, usize)> {
             }
         }
 
-        content.push_str(line);
-        content.push('\n');
+        if !open_tag.is_empty() {
+            content.push_str(line);
+            content.push('\n');
+        }
     }
 
     None
@@ -165,6 +167,20 @@ mod test {
         assert_eq!(
             parse_html_block(&vec!["<div>", "    more text", "</div>"]).unwrap(),
             ((HtmlBlock("<div>\n    more text\n</div>\n".to_owned()), 3))
+        );
+
+        assert_eq!(
+            parse_html_block(&vec![
+                "<div class=\"csv\">",
+                "<table>",
+                "</table>",
+                "</div>"
+            ])
+            .unwrap(),
+            ((
+                HtmlBlock("<div class=\"csv\">\n<table>\n</table>\n</div>\n".to_owned()),
+                4
+            ))
         );
     }
 

--- a/src/parser/block/html_block.rs
+++ b/src/parser/block/html_block.rs
@@ -1,0 +1,344 @@
+use parser::Block;
+use parser::Block::HtmlBlock;
+
+const BLOCK_TAGS: [&str; 27] = [
+    "p",
+    "div",
+    "h1",
+    "h2",
+    "h3",
+    "h4",
+    "h5",
+    "h6",
+    "blockquote",
+    "pre",
+    "table",
+    "dl",
+    "ol",
+    "ul",
+    "script",
+    "noscript",
+    "form",
+    "fieldset",
+    "iframe",
+    "math",
+    "ins",
+    "del",
+    "hr",
+    "hr/",
+    "br",
+    "br/",
+    "!--", //Pseudo tag to deal with HTML comments
+];
+
+const SPECIAL_TAGS: [&str; 4] = ["hr", "hr/", "br", "br/"];
+
+const COMMENT_START_TAG: &str = "<!--";
+const COMMENT_END_TAG: &str = "-->";
+
+fn find_tag(line: &str) -> Option<(&str, usize, usize)> {
+    if let Some(head) = line.find(COMMENT_START_TAG) {
+        let tail = head + 4;
+        return Some(("!--", head, tail));
+    } else if let Some(head) = line.find(COMMENT_END_TAG) {
+        let tail = head + 3;
+        return Some(("/!--", head, tail));
+    } else if let Some(head) = line.find('<') {
+        if let Some(len) = line[head..].find('>') {
+            let tail = head + len + 1;
+            let start = head + 1;
+            let end;
+            let mut fields = line[head..tail].split_whitespace();
+            if let Some(tagid) = fields.next() {
+                end = match fields.next() {
+                    Some(_) => head + tagid.len(),
+                    None => tail - 1,
+                }
+            } else {
+                end = tail - 1;
+            }
+            if end < line.len() {
+                let tag = &line[start..end];
+                return Some((tag, head, tail));
+            }
+        }
+    }
+    None
+}
+
+pub fn parse_html_block(lines: &[&str]) -> Option<(Block, usize)> {
+    let mut content = String::new();
+    let mut line_count = 0;
+    let mut nest_count = 0;
+    let mut open_tag: &str = "";
+
+    for line in lines {
+        let line = line.trim_end();
+        let mut offset = 0;
+        line_count += 1;
+
+        // Parse all HTML tags in the line.
+        while let Some((tag, h, t)) = find_tag(&line[offset..]) {
+            let idx = offset + h;
+            offset += t;
+            if open_tag.len() > 0 {
+                if tag == open_tag {
+                    // Deal with matching nested start-tags.
+                    nest_count += 1;
+                } else if let Some(tag) = tag.strip_prefix('/') {
+                    // An end-tag was found.
+                    if tag == open_tag {
+                        if nest_count > 0 {
+                            nest_count -= 1;
+                        } else if offset == line.len() {
+                            // The final matching end-tag was found.
+                            content.push_str(line);
+                            content.push('\n');
+                            return Some((HtmlBlock(content), line_count));
+                        } else {
+                            return None;
+                        }
+                    }
+                }
+            } else if line_count == 1 && idx == 0 && BLOCK_TAGS.contains(&tag) {
+                // A tag for the start of an HTML block was found (a start-tag).
+                if SPECIAL_TAGS.contains(&tag) {
+                    // Special case for single one line tags (like BR and HR)
+                    content.push_str(line);
+                    content.push('\n');
+                    return Some((HtmlBlock(content), line_count));
+                } else {
+                    open_tag = tag;
+                }
+            } else {
+                return None;
+            }
+
+            if offset >= line.len() {
+                // End of the line.
+                break;
+            }
+        }
+
+        content.push_str(line);
+        content.push('\n');
+    }
+
+    None
+}
+
+/***************************************************************************************************/
+#[cfg(test)]
+mod test {
+    use super::find_tag;
+    use super::parse_html_block;
+    use parser::Block::HtmlBlock;
+
+    #[test]
+    fn find_tag_basic() {
+        assert_eq!(find_tag("<div>"), Some(("div", 0, 5)));
+        assert_eq!(find_tag("</div>"), Some(("/div", 0, 6)));
+        assert_eq!(find_tag("  <div>  "), Some(("div", 2, 7)));
+        assert_eq!(find_tag("  </div>  "), Some(("/div", 2, 8)));
+        assert_eq!(find_tag("deadbeef<div>deadbeef"), Some(("div", 8, 13)));
+    }
+
+    #[test]
+    fn find_tag_special() {
+        assert_eq!(find_tag("<hr>"), Some(("hr", 0, 4)));
+        assert_eq!(find_tag("<hr/>"), Some(("hr/", 0, 5)));
+        assert_eq!(find_tag("<hr />"), Some(("hr", 0, 6)));
+        assert_eq!(find_tag("  <hr>  "), Some(("hr", 2, 6)));
+        assert_eq!(find_tag("  <hr/>  "), Some(("hr/", 2, 7)));
+        assert_eq!(find_tag("  <hr />  "), Some(("hr", 2, 8)));
+        assert_eq!(find_tag("  <hr class=\"thick\">  "), Some(("hr", 2, 20)));
+        assert_eq!(find_tag(" <hr  class=\"thick\" />  "), Some(("hr", 1, 22)));
+    }
+
+    #[test]
+    fn finds_block() {
+        assert_eq!(
+            parse_html_block(&vec!["<div>   ", "  the block  ", "</div>   "]).unwrap(),
+            ((HtmlBlock("<div>\n  the block\n</div>\n".to_owned()), 3))
+        );
+
+        assert_eq!(
+            parse_html_block(&vec!["<div>", "    more text", "</div>"]).unwrap(),
+            ((HtmlBlock("<div>\n    more text\n</div>\n".to_owned()), 3))
+        );
+    }
+
+    #[test]
+    fn knows_when_to_stop() {
+        assert_eq!(
+            parse_html_block(&vec![
+                "<div>",
+                "    Test",
+                "    this",
+                "stuff",
+                "    now",
+                "</div>    "
+            ])
+            .unwrap(),
+            ((
+                HtmlBlock("<div>\n    Test\n    this\nstuff\n    now\n</div>\n".to_owned()),
+                6
+            ))
+        );
+    }
+
+    #[test]
+    fn no_false_positives() {
+        assert_eq!(
+            parse_html_block(&vec!["</table>", "    this", "stuff", "    now", "</div>"]),
+            None
+        );
+        assert_eq!(
+            parse_html_block(&vec!["<table>", "    this", "stuff", "    now", "</div>"]),
+            None
+        );
+        assert_eq!(
+            parse_html_block(&vec![
+                "<table>",
+                "<table>    this",
+                "stuff",
+                "    now",
+                "</table>"
+            ]),
+            None
+        );
+    }
+
+    #[test]
+    fn no_early_matching() {
+        assert_eq!(
+            parse_html_block(&vec![" <div>", "    this", "stuff", "</div>"]),
+            None
+        );
+        assert_eq!(
+            parse_html_block(&vec!["xyz", "<div>", "    this", "stuff", "</div>"]),
+            None
+        );
+        assert_eq!(
+            parse_html_block(&vec!["xyz<div>", "    this", "stuff", "</div>"]),
+            None
+        );
+        assert_eq!(
+            parse_html_block(&vec!["<div>", "    this", "stuff", "</div>xyz"]),
+            None
+        );
+        assert_eq!(
+            parse_html_block(&vec!["wyz <div>", "    this", "stuff", "</div>"]),
+            None
+        );
+        assert_eq!(
+            parse_html_block(&vec!["<div>", "    this", "stuff", "</div> xyz "]),
+            None
+        );
+    }
+
+    #[test]
+    fn ignore_nested_tags() {
+        assert_eq!(
+            parse_html_block(&vec![
+                "<table>",
+                "<table>",
+                "<table></table>",
+                "<table>",
+                "</table>",
+                "</table>",
+                "</table>",
+                "continued texted"
+            ])
+            .unwrap(),
+            ((
+                HtmlBlock(
+                    "<table>\n<table>\n<table></table>\n<table>\n</table>\n</table>\n</table>\n"
+                        .to_owned()
+                ),
+                7
+            ))
+        );
+
+        assert_eq!(
+            parse_html_block(&vec!["<div>","    <div>", "    this", "<div></div>", " is ", "<div>", "stuff" , "</div>", "    done", "</div> xyz </div>   ", "continued texted"]).unwrap(),
+            ((HtmlBlock("<div>\n    <div>\n    this\n<div></div>\n is\n<div>\nstuff\n</div>\n    done\n</div> xyz </div>\n".to_owned()), 10))
+        );
+    }
+
+    #[test]
+    fn finds_html_comment_line() {
+        assert_eq!(
+            parse_html_block(&vec!["<!-- one line comment -->", "next line"]).unwrap(),
+            ((HtmlBlock("<!-- one line comment -->\n".to_owned()), 1))
+        );
+        assert_eq!(
+            parse_html_block(&vec!["<!--one line comment-->    "]).unwrap(),
+            ((HtmlBlock("<!--one line comment-->\n".to_owned()), 1))
+        );
+    }
+
+    #[test]
+    fn finds_html_comment_block() {
+        assert_eq!(
+            parse_html_block(&vec![
+                "<!--",
+                "  this is a",
+                "  comment block",
+                "-->",
+                "next line"
+            ])
+            .unwrap(),
+            ((
+                HtmlBlock("<!--\n  this is a\n  comment block\n-->\n".to_owned()),
+                4
+            ))
+        );
+        assert_eq!(
+            parse_html_block(&vec![
+                "<!-- followed by  ",
+                "  another",
+                "  comment block",
+                "style-->",
+                "next line"
+            ])
+            .unwrap(),
+            ((
+                HtmlBlock("<!-- followed by\n  another\n  comment block\nstyle-->\n".to_owned()),
+                4
+            ))
+        );
+    }
+
+    #[test]
+    fn finds_html_horizontal_rule() {
+        assert_eq!(
+            parse_html_block(&vec!["<hr>", "next line"]).unwrap(),
+            ((HtmlBlock("<hr>\n".to_owned()), 1))
+        );
+        assert_eq!(
+            parse_html_block(&vec!["<hr/>", "next line"]).unwrap(),
+            ((HtmlBlock("<hr/>\n".to_owned()), 1))
+        );
+        assert_eq!(
+            parse_html_block(&vec!["<hr \t/>", "next line"]).unwrap(),
+            ((HtmlBlock("<hr \t/>\n".to_owned()), 1))
+        );
+    }
+
+    #[test]
+    fn finds_html_line_break() {
+        assert_eq!(
+            parse_html_block(&vec!["<br>", "next line"]).unwrap(),
+            ((HtmlBlock("<br>\n".to_owned()), 1))
+        );
+        assert_eq!(
+            parse_html_block(&vec!["<br/>", "next line"]).unwrap(),
+            ((HtmlBlock("<br/>\n".to_owned()), 1))
+        );
+        assert_eq!(
+            parse_html_block(&vec!["<br\t />", "next line"]).unwrap(),
+            ((HtmlBlock("<br\t />\n".to_owned()), 1))
+        );
+    }
+}

--- a/src/parser/block/mod.rs
+++ b/src/parser/block/mod.rs
@@ -7,6 +7,7 @@ mod atx_header;
 mod blockquote;
 mod code_block;
 mod hr;
+mod html_block;
 mod link_reference;
 mod ordered_list;
 mod setext_header;
@@ -15,6 +16,7 @@ use self::atx_header::parse_atx_header;
 use self::blockquote::parse_blockquote;
 use self::code_block::parse_code_block;
 use self::hr::parse_hr;
+use self::html_block::parse_html_block;
 use self::link_reference::parse_link_reference;
 use self::ordered_list::parse_ordered_list;
 use self::setext_header::parse_setext_header;
@@ -74,6 +76,7 @@ fn parse_block(lines: &[&str]) -> Option<(Block, usize)> {
     => parse_hr
     => parse_atx_header
     => parse_code_block
+    => parse_html_block
     => parse_blockquote
     => parse_unordered_list
     => parse_ordered_list

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -40,6 +40,7 @@ pub enum Block {
     Paragraph(Vec<Span>),
     Blockquote(Vec<Block>),
     CodeBlock(Option<String>, String),
+    HtmlBlock(String),
     /** A link reference with the fields: (id, url, [title]) **/
     LinkReference(String, String, Option<String>),
     OrderedList(Vec<ListItem>, OrderedListType),

--- a/tests/fixtures/files/advanced_inline_html.html
+++ b/tests/fixtures/files/advanced_inline_html.html
@@ -1,0 +1,30 @@
+<p>Simple block on one line:</p>
+
+<div>foo</div>
+
+<p>And nested without indentation:</p>
+
+<div>
+<div>
+<div>
+foo
+</div>
+<!-- <div style=">"/> Not supported -->
+</div>
+<div>bar</div>
+</div>
+
+<p>And with attributes:</p>
+
+<div>
+	<div id="foo">
+	</div>
+</div>
+
+<p>This was broken in 1.0.2b7:</p>
+
+<div class="inlinepage">
+<div class="toggleableend">
+foo
+</div>
+</div>

--- a/tests/fixtures/files/advanced_inline_html.text
+++ b/tests/fixtures/files/advanced_inline_html.text
@@ -1,0 +1,30 @@
+Simple block on one line:
+
+<div>foo</div>
+
+And nested without indentation:
+
+<div>
+<div>
+<div>
+foo
+</div>
+<!-- <div style=">"/> Not supported -->
+</div>
+<div>bar</div>
+</div>
+
+And with attributes:
+
+<div>
+	<div id="foo">
+	</div>
+</div>
+
+This was broken in 1.0.2b7:
+
+<div class="inlinepage">
+<div class="toggleableend">
+foo
+</div>
+</div>

--- a/tests/fixtures/files/inline_html_comments.html
+++ b/tests/fixtures/files/inline_html_comments.html
@@ -1,0 +1,13 @@
+<p>Paragraph one.</p>
+
+<!-- This is a simple comment -->
+
+<!--
+	This is another comment.
+-->
+
+<p>Paragraph two.</p>
+
+<!-- one comment block -- -- with two comments -->
+
+<p>The end.</p>

--- a/tests/fixtures/files/inline_html_comments.text
+++ b/tests/fixtures/files/inline_html_comments.text
@@ -1,0 +1,13 @@
+Paragraph one.
+
+<!-- This is a simple comment -->
+
+<!--
+	This is another comment.
+-->
+
+Paragraph two.
+
+<!-- one comment block -- -- with two comments -->
+
+The end.

--- a/tests/fixtures/files/simple_inline_html.html
+++ b/tests/fixtures/files/simple_inline_html.html
@@ -1,0 +1,68 @@
+<p>Here&#8217;s a simple block:</p>
+
+<div>
+    foo
+</div>
+
+<p>This should be a code block, though:</p>
+
+<pre><code>&lt;div&gt;
+    foo
+&lt;/div&gt;</code></pre>
+
+<p>As should this:</p>
+
+<pre><code>&lt;div&gt;foo&lt;/div&gt;</code></pre>
+
+<p>Now, nested:</p>
+
+<div>
+    <div>
+        <div>
+            foo
+        </div>
+    </div>
+</div>
+
+<p>This should just be an HTML comment:</p>
+
+<!-- Comment -->
+
+<p>Multiline:</p>
+
+<!--
+Blah
+Blah
+-->
+
+<p>Code block:</p>
+
+<pre><code>&lt;!-- Comment --&gt;</code></pre>
+
+<p>Just plain comment, with trailing spaces on the line:</p>
+
+<!-- foo -->
+
+<p>Code:</p>
+
+<pre><code>&lt;hr /&gt;</code></pre>
+
+<p>Hr&#8217;s:</p>
+
+<hr>
+
+<hr/>
+
+<hr />
+
+<hr>
+
+<hr/>
+
+<hr />
+
+<hr class="foo" id="bar" />
+
+<hr class="foo" id="bar"/>
+
+<hr class="foo" id="bar" >

--- a/tests/fixtures/files/simple_inline_html.text
+++ b/tests/fixtures/files/simple_inline_html.text
@@ -1,0 +1,69 @@
+Here's a simple block:
+
+<div>
+    foo
+</div>
+
+This should be a code block, though:
+
+    <div>
+        foo
+    </div>
+
+As should this:
+
+    <div>foo</div>
+
+Now, nested:
+
+<div>
+    <div>
+        <div>
+            foo
+        </div>
+    </div>
+</div>
+
+This should just be an HTML comment:
+
+<!-- Comment -->
+
+Multiline:
+
+<!--
+Blah
+Blah
+-->
+
+Code block:
+
+    <!-- Comment -->
+
+Just plain comment, with trailing spaces on the line:
+
+<!-- foo -->    
+
+Code:
+
+    <hr />
+
+Hr's:
+
+<hr>
+
+<hr/>
+
+<hr />
+
+<hr>
+
+<hr/>
+
+<hr />
+
+<hr class="foo" id="bar" />
+
+<hr class="foo" id="bar"/>
+
+<hr class="foo" id="bar" >
+

--- a/tests/fixtures/mod.rs
+++ b/tests/fixtures/mod.rs
@@ -312,3 +312,18 @@ pub fn wrapping() {
 pub fn rt_wrapping() {
     roundtrip("wrapping")
 }
+
+#[test]
+pub fn simple_inline_html() {
+    compare("simple_inline_html")
+}
+
+#[test]
+pub fn inline_html_comments() {
+    compare("inline_html_comments")
+}
+
+#[test]
+pub fn advanced_inline_html() {
+    compare("advanced_inline_html")
+}


### PR DESCRIPTION
Hi Johann,

Thank you for the great markdown crate. I am using it in a small Rocket Web application, I'm developing for my company. However I need support for inline HTML so I decided to try contribute to the crate and offer a solution for this feature.

Web development is not my expertise and I am also very new to Rust (coming from a C background). Hopefully I haven't gone too far off the rails, and you can use/merge my solution. It seems to pass most of the tests except a weird xHTML case, which I have noted in the file `tests/fixtures/files/advanced_inline_html.text`.
   
Regards
Dario
