### PR TITLE
Reduce number of Regex::is_match calls

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,4 +28,9 @@ regex = "1"
 
 [dev-dependencies]
 difference = "0.4"
+criterion = "0.3"
+
+[[bench]]
+name = "to_html"
+harness = false
 

--- a/benches/to_html.rs
+++ b/benches/to_html.rs
@@ -1,0 +1,27 @@
+extern crate criterion;
+extern crate markdown;
+
+use std::fs::File;
+use std::io::Read;
+use std::path::Path;
+
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+
+pub fn bench_easy(c: &mut Criterion) {
+    let text = format!("tests/fixtures/files/{}.text", "easy");
+    let md = Path::new(&text);
+
+    let mut tokens = String::new();
+    File::open(md).unwrap().read_to_string(&mut tokens).unwrap();
+
+    c.bench_function("bench_easy", |b| {
+        b.iter(|| {
+            for i in 1..=100 {
+                black_box(markdown::to_html(&tokens));
+            }
+        });
+    });
+}
+
+criterion_group!(benches, bench_easy);
+criterion_main!(benches);

--- a/src/parser/span/emphasis.rs
+++ b/src/parser/span/emphasis.rs
@@ -5,17 +5,16 @@ use regex::Regex;
 
 pub fn parse_emphasis(text: &str) -> Option<(Span, usize)> {
     lazy_static! {
-        static ref EMPHASIS_UNDERSCORE: Regex = Regex::new(r"^_(?P<text>.+?)_").unwrap();
-        static ref EMPHASIS_STAR: Regex = Regex::new(r"^\*(?P<text>.+?)\*").unwrap();
+        static ref EMPHASIS: Regex =
+            Regex::new(r"^_(?P<underscore_text>.+?)_|^\*(?P<star_text>.+?)\*").unwrap();
     }
 
-    if EMPHASIS_UNDERSCORE.is_match(text) {
-        let caps = EMPHASIS_UNDERSCORE.captures(text).unwrap();
-        let t = caps.name("text").unwrap().as_str();
-        return Some((Emphasis(parse_spans(t)), t.len() + 2));
-    } else if EMPHASIS_STAR.is_match(text) {
-        let caps = EMPHASIS_STAR.captures(text).unwrap();
-        let t = caps.name("text").unwrap().as_str();
+    if EMPHASIS.is_match(text) {
+        let caps = EMPHASIS.captures(text).expect("is_match returned true");
+        let t = caps
+            .name("underscore_text")
+            .unwrap_or_else(|| caps.name("star_text").unwrap())
+            .as_str();
         return Some((Emphasis(parse_spans(t)), t.len() + 2));
     }
     None

--- a/src/parser/span/strong.rs
+++ b/src/parser/span/strong.rs
@@ -5,17 +5,16 @@ use regex::Regex;
 
 pub fn parse_strong(text: &str) -> Option<(Span, usize)> {
     lazy_static! {
-        static ref STRONG_UNDERSCORE: Regex = Regex::new(r"^__(?P<text>.+?)__").unwrap();
-        static ref STRONG_STAR: Regex = Regex::new(r"^\*\*(?P<text>.+?)\*\*").unwrap();
+        static ref STRONG: Regex =
+            Regex::new(r"^__(?P<underscore_text>.+?)__|^\*\*(?P<star_text>.+?)\*\*").unwrap();
     }
 
-    if STRONG_UNDERSCORE.is_match(text) {
-        let caps = STRONG_UNDERSCORE.captures(text).unwrap();
-        let t = caps.name("text").unwrap().as_str();
-        return Some((Strong(parse_spans(t)), t.len() + 4));
-    } else if STRONG_STAR.is_match(text) {
-        let caps = STRONG_STAR.captures(text).unwrap();
-        let t = caps.name("text").unwrap().as_str();
+    if STRONG.is_match(text) {
+        let caps = STRONG.captures(text).expect("is_match returned true");
+        let t = caps
+            .name("underscore_text")
+            .unwrap_or_else(|| caps.name("star_text").unwrap())
+            .as_str();
         return Some((Strong(parse_spans(t)), t.len() + 4));
     }
     None


### PR DESCRIPTION
Hello! I wanted to start by thanking you for the work on this crate, it's made my life easier :smile: 

I was doing some profiling on a toy blog engine I've been writing and was surprised to see both that Markdown parsing was dominating time spent in my webserver and that, within the `markdown` crate, most of the time spent doing that was in `Regex::is_match`. I'm not super familiar with this code so I didn't go for any super involved change though after looking around I was wondering whether the looping calls to `parse_span` from `parse_spans` could be removed, maybe if character escaping was handled externally to parse_spans? Anyway, while looking around I did notice a small change that could be made to slightly reduce `Regex::is_match` calls but perhaps at the cost of more complex/harder to maintain regular expressions, so I'd understand if you didn't want to make that tradeoff. My commit message below outlines the change:

Regex::is_match accounts for a large portion of time spent parsing
Markdown text. This seems to be because the regexes are checked for
matches iteratively with varying size slices in
markdown::parser::span::parse_spans. Code, emphasis, and strong checks
were double the time of the other span checks due to using two regexes
and calling is_match on both of them with each iteration.

This commit combines the regexes in code, emphasis, and strong tag
parsing into a single regex for each tag. The result is that checks for
these tags now take roughly the same amount of time as for the checks
for other tags. The Regex::is_match calls still dominate time spent in
parsing but this is a marginal improvement.

I've also added a very basic benchmark based on the "easy.txt" test
fixture. This is certainly not a representative markdown document but
running markdown::to_html against it does show improvement with this
change. This seems to be because it uses both emphasis and strong tags
and those are checked after code tags in parse_span, therefore all three
of the improved tag checks are exercised in this benchmark.

I realize testing against such a small markdown file probably doesn't give the best results for a benchmark. However, when running criterion before and then after my change it says:

```
bench_easy              time:   [487.56 us 489.91 us 493.19 us]
                        change: [-16.457% -15.504% -14.092%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  5 (5.00%) high severe
```

I have a screenshot of the report below. I also have images of the profile from my webserver before and after, you can see in the after screenshot that each of `parse_code`, `parse_strong`, and `parse_emphasis` now take roughly equal time to the other span checks like `parse_break`, etc instead of double.

![markdown rs-criterion-report](https://user-images.githubusercontent.com/403152/103504223-67a74b80-4e1c-11eb-886e-420c142cfe4a.png)

Profile from my web project, before:
![markdown rs bottom-up-before](https://user-images.githubusercontent.com/403152/103504372-dc7a8580-4e1c-11eb-966d-ef2d0d72f1b0.png)


Profile from my web project, after: 
![markdownrs bottom-up-after](https://user-images.githubusercontent.com/403152/103504243-78f05800-4e1c-11eb-902e-404d936823f2.png)


Interested to hear what you think about this change and thanks again!