### PR TITLE
Fixes #43

### DIFF
--- a/src/parser/block/unordered_list.rs
+++ b/src/parser/block/unordered_list.rs
@@ -82,8 +82,10 @@ pub fn parse_unordered_list(lines: &[&str]) -> Option<(Block, usize)> {
     for c in contents {
         if is_paragraph || c.len() > 1 {
             list_contents.push(ListItem::Paragraph(c));
-        } else if let Paragraph(content) = c[0].clone() {
-            list_contents.push(ListItem::Simple(content));
+        } else if c.len() != 0 { 
+            if let Paragraph(content) = c[0].clone() {
+                list_contents.push(ListItem::Simple(content));
+            }
         }
     }
 


### PR DESCRIPTION
Fixes #43. Perhaps after the last else if, you could push the text. But as of now, `- ` and `8 ` panic when converted