### PR TITLE
Fix out of bounds 

### DIFF
--- a/src/parser/block/link_reference.rs
+++ b/src/parser/block/link_reference.rs
@@ -23,6 +23,8 @@ pub fn parse_link_reference(lines: &[&str]) -> Option<(Block, usize)> {
             1,
         ));
     }
+    
+    if lines.len() < 2 { return None }
 
     if LINK_REFERENCE_FIRST_LINE.is_match(lines[0]) && LINK_REFERENCE_SECOND_LINE.is_match(lines[1])
     {

--- a/src/parser/block/ordered_list.rs
+++ b/src/parser/block/ordered_list.rs
@@ -84,7 +84,7 @@ pub fn parse_ordered_list(lines: &[&str]) -> Option<(Block, usize)> {
 
     let mut list_contents = vec![];
 
-    for c in contents {
+    for c in contents.into_iter().filter(|x| !x.is_empty()) {
         if is_paragraph || c.len() > 1 {
             list_contents.push(ListItem::Paragraph(c));
         } else if let Paragraph(content) = c[0].clone() {

--- a/src/parser/block/unordered_list.rs
+++ b/src/parser/block/unordered_list.rs
@@ -79,7 +79,7 @@ pub fn parse_unordered_list(lines: &[&str]) -> Option<(Block, usize)> {
 
     let mut list_contents = vec![];
 
-    for c in contents {
+    for c in contents.into_iter().filter(|x| !x.is_empty()) {
         if is_paragraph || c.len() > 1 {
             list_contents.push(ListItem::Paragraph(c));
         } else if let Paragraph(content) = c[0].clone() {


### PR DESCRIPTION
Fixes #43 #45 
Sometimes this iter over the Vec<Vec<block>> would return an empty Vec<Block> meaning the call for c[0] would fail.

"0 " 
"- "

These two inputs would crash it. This filters it so only non-empty vec's are iter'd over