### PR TITLE
Add generate_html to lib.rs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,8 +38,8 @@ pub fn generate_markdown(x: Vec<Block>) -> String {
 }
 
 /// Convert tokenset of Markdown items to html
-pub fn generate_html(x: Vec<Block>) -> String {
-    html::to_html(&result)
+pub fn generate_html(x: &Vec<Block>) -> String {
+    html::to_html(x)
 }
 
 /// Opens a file and converts its contents to HTML

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,6 +37,11 @@ pub fn generate_markdown(x: Vec<Block>) -> String {
     markdown_generator::generate(x)
 }
 
+/// Convert tokenset of Markdown items to html
+pub fn generate_html(x: Vec<Block>) -> String {
+    html::to_html(&result)
+}
+
 /// Opens a file and converts its contents to HTML
 pub fn file_to_html(path: &Path) -> io::Result<String> {
     let mut file = File::open(path)?;


### PR DESCRIPTION
Adds `generate_html` to the library. Allowing the user to generate HTML from a `Vec<Block>`. 

Right now my program has to: 
```rs
let blocks = markdown::tokenize(input);
// modify blocks here
let md = markdown::generate_markdown(blocks);
return markdown::to_html(&md);
```
This would allow me to write it like this instead:
```rs
let blocks = markdown::tokenize(input);
// modify blocks here
return markdown::generate_html(blocks);
```